### PR TITLE
walking: initialize bio ik only once

### DIFF
--- a/bitbots_quintic_walk/src/QuinticWalkingNode.cpp
+++ b/bitbots_quintic_walk/src/QuinticWalkingNode.cpp
@@ -1,7 +1,8 @@
 #include "bitbots_quintic_walk/QuinticWalkingNode.hpp"
 
 
-QuinticWalkingNode::QuinticWalkingNode() {
+QuinticWalkingNode::QuinticWalkingNode() :
+        _robot_model_loader("/robot_description", false) {
     // init variables
     _robotState = humanoid_league_msgs::RobotControlState::CONTROLABLE;
     _walkEngine = bitbots_quintic_walk::QuinticWalk();
@@ -38,7 +39,6 @@ QuinticWalkingNode::QuinticWalkingNode() {
     _pubDebugMarker = _nh.advertise<visualization_msgs::Marker>("walk_debug_marker", 1);
 
     //load MoveIt! model    
-    _robot_model_loader = robot_model_loader::RobotModelLoader("/robot_description", false);
     _robot_model_loader.loadKinematicsSolvers(
             kinematics_plugin_loader::KinematicsPluginLoaderPtr(
                     new kinematics_plugin_loader::KinematicsPluginLoader()));


### PR DESCRIPTION
Currently, the robot model loader (and therefore the bio ik) is initialized twice when the walking starts: Once in the header file where it is declared and a second time in the constructor. This PR moves the initialization to the member initializer list. Thereby, it is only initialized once. 
This kind of double initialization occurs currently quite often, e.g. for the WalkEngine. Those initializations could also be moved to the initializer list, but that is not so crucial as their initialization is not as time consuming.