### PR TITLE
QuinticWalk: added stability criteria for imu angular velocity

### DIFF
--- a/bitbots_quintic_walk/cfg/bitbots_quintic_walk_params.cfg
+++ b/bitbots_quintic_walk/cfg/bitbots_quintic_walk_params.cfg
@@ -100,6 +100,10 @@ group_stability.add("imuPitchThreshold", double_t, 1,
         "Threshold for stopping for the robot pitch [rad]", min=0, max=1)
 group_stability.add("imuRollThreshold", double_t, 1,
         "Threshold for stopping for the robot roll [rad]", min=0, max=1)
+group_stability.add("imuPitchVelThreshold", double_t, 1,
+                    "Threshold for stopping for the robot pitch angular velocity [rad/s]", min=0, max=1)
+group_stability.add("imuRollVelThreshold", double_t, 1,
+                    "Threshold for stopping for the robot roll angular velocity [rad/s]", min=0, max=1)
 
 
 group_limits.add("maxStepX", double_t, 1,

--- a/bitbots_quintic_walk/config/walking_wolfgang_robot.yaml
+++ b/bitbots_quintic_walk/config/walking_wolfgang_robot.yaml
@@ -91,4 +91,6 @@ walking:
   imuActive: False
   imuPitchThreshold: 1.0
   imuRollThreshold: 1.0
+  imuPitchVelThreshold: 1.0
+  imuRollVelThreshold: 1.0
   pauseDuration: 1.0

--- a/bitbots_quintic_walk/include/bitbots_quintic_walk/QuinticWalkingNode.hpp
+++ b/bitbots_quintic_walk/include/bitbots_quintic_walk/QuinticWalkingNode.hpp
@@ -84,6 +84,9 @@ private:
     bool _imuActive;
     double _imu_pitch_threshold;
     double _imu_roll_threshold;
+    double _imu_pitch_vel_threshold;
+    double _imu_roll_vel_threshold;
+
 
     int _odomPubFactor;
     std::chrono::time_point<std::chrono::steady_clock> _last_update_time;

--- a/bitbots_quintic_walk/src/QuinticWalkingNode.cpp
+++ b/bitbots_quintic_walk/src/QuinticWalkingNode.cpp
@@ -237,7 +237,7 @@ void QuinticWalkingNode::imuCb(const sensor_msgs::Imu msg) {
         double pitch_vel = msg.angular_velocity.y;
 
 
-        if (abs(roll) > _imu_roll_threshold || abs(pitch) > _imu_pitch_threshold || pitch_vel > _imu_pitch_vel_threshold || roll_vel > _imu_roll_vel_threshold) {
+        if (abs(roll) > _imu_roll_threshold || abs(pitch) > _imu_pitch_threshold || abs(pitch_vel) > _imu_pitch_vel_threshold || abs(roll_vel) > _imu_roll_vel_threshold) {
             _walkEngine.requestPause();
         }
     }

--- a/bitbots_quintic_walk/src/QuinticWalkingNode.cpp
+++ b/bitbots_quintic_walk/src/QuinticWalkingNode.cpp
@@ -230,10 +230,14 @@ void QuinticWalkingNode::imuCb(const sensor_msgs::Imu msg) {
         // compute the pitch offset to the currently wanted pitch of the engine
         double wanted_pitch = _params.trunkPitch + _params.trunkPitchPCoefForward*_walkEngine.getFootstep().getNext().x()
         + _params.trunkPitchPCoefTurn*fabs(_walkEngine.getFootstep().getNext().z());
-
         pitch = pitch - wanted_pitch;
 
-        if (abs(roll) > _imu_roll_threshold || abs(pitch) > _imu_pitch_threshold) {
+        // get angular velocities
+        double roll_vel = msg.angular_velocity.x;
+        double pitch_vel = msg.angular_velocity.y;
+
+
+        if (abs(roll) > _imu_roll_threshold || abs(pitch) > _imu_pitch_threshold || pitch_vel > _imu_pitch_vel_threshold || roll_vel > _imu_roll_vel_threshold) {
             _walkEngine.requestPause();
         }
     }
@@ -364,6 +368,8 @@ QuinticWalkingNode::reconf_callback(bitbots_quintic_walk::bitbots_quintic_walk_p
     _imuActive = config.imuActive;
     _imu_pitch_threshold = config.imuPitchThreshold;
     _imu_roll_threshold = config.imuRollThreshold;
+    _imu_pitch_vel_threshold = config.imuPitchVelThreshold;
+    _imu_roll_vel_threshold = config.imuRollVelThreshold;
 
     _phaseResetActive = config.phaseResetActive;
     _groundMinPressure = config.groundMinPressure;


### PR DESCRIPTION
tested in visualization, good values still have to be found. since imu is default deactivated currently, I think we can merge this on the master