### PR TITLE
use falling animations for falling to right and left instead of walkready

### DIFF
--- a/bitbots_hcm/config/hcm_wolfgang.yaml
+++ b/bitbots_hcm/config/hcm_wolfgang.yaml
@@ -16,10 +16,10 @@ hcm:
   animations:
     walkready: "walkready"
     walkready_sim: "init"
-    falling_front: "falling_front" # TODO Animation Falling
+    falling_front: "falling_front"
     falling_back: "falling_back"
-    falling_left: "walkready"
-    falling_right: "walkready"
+    falling_left: "falling_left"
+    falling_right: "falling_right"
     stand_up_front: "stand_up_front_fast"
     stand_up_back: "stand_up_back_fast"
     stand_up_left: "turning_back_left"


### PR DESCRIPTION
@johagge wanted a pull request for this change.