### PR TITLE
QuinticWalk: multiple start movements

### DIFF
--- a/bitbots_quintic_walk/config/walking_wolfgang_robot.yaml
+++ b/bitbots_quintic_walk/config/walking_wolfgang_robot.yaml
@@ -98,3 +98,4 @@ walking:
   publishOdomTF: True
 
   firstStepSwingFactor: 1.0
+  startMovements: 1


### PR DESCRIPTION
adds a parameter to chose how many start movements the robot does before starting to walk