### PR TITLE
QuinticWalk: build speed up

### DIFF
--- a/bitbots_quintic_walk/CMakeLists.txt
+++ b/bitbots_quintic_walk/CMakeLists.txt
@@ -75,18 +75,8 @@ set(CODE_LIBRARIES
         urdfdom_model
 )
 
-add_library(${PROJECT_NAME} ${SOURCES})
-
-
-add_executable(QuinticWalkingNode
-        src/QuinticWalkingNode.cpp
-    src/QuinticWalk/WalkEngine.cpp
-)
+add_executable(QuinticWalkingNode ${SOURCES})
 
 add_dependencies(QuinticWalkingNode ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS} ${PROJECT_NAME}_gencfg)
-add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS} ${PROJECT_NAME}_generate_messages_cpp)
 
-
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${CODE_LIBRARIES})
-
-target_link_libraries(QuinticWalkingNode ${catkin_LIBRARIES} ${PROJECT_NAME})
+target_link_libraries(QuinticWalkingNode ${catkin_LIBRARIES} ${CODE_LIBRARIES})


### PR DESCRIPTION
removed building unnecessary library for compiling speed up
Improved time for compiling on my laptop from 66s to 36s