### PR TITLE
switch to bitbots_docs documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,12 @@
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # auto-generated documentation
-**/doc/_build
-**/doc/_generated
-**/doc/manifest.yaml
-**/doc/html
+**/docs/index.rst
+**/docs/conf.py
+**/docs/_build
+**/docs/_out
+**/docs/pyapi
+**/docs/cppapi
 
 # User-specific stuff:
 .idea/workspace.xml

--- a/bitbots_dynamic_kick/CMakeLists.txt
+++ b/bitbots_dynamic_kick/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(catkin REQUIRED COMPONENTS
         std_msgs
         visualization_msgs
         nav_msgs
-        )
+        bitbots_docs)
 
 generate_dynamic_reconfigure_options(
         cfg/bitbots_dynamic_kick_params.cfg
@@ -39,7 +39,7 @@ set(SOURCES
         src/kick_ik.cpp)
 
 add_executable(KickNode ${SOURCES})
-
 add_dependencies(KickNode ${PROJECT_NAME}_gencfg)
-
 target_link_libraries(KickNode ${catkin_LIBRARIES})
+
+enable_bitbots_docs()

--- a/bitbots_dynamic_kick/package.xml
+++ b/bitbots_dynamic_kick/package.xml
@@ -3,8 +3,9 @@
   <name>bitbots_dynamic_kick</name>
   <version>0.1.2</version>
   <description>
-	  The bitbots_dynamic_kick package implements a kick which is not based on keyframe animations.
-	  Instead it aims to dynamically reach it's movement goal while keeping the robot stable and controllable.
+      The bitbots_dynamic_kick package implements a kick which is not based on keyframe animations.
+
+      Instead it aims to dynamically reach it's movement goal while keeping the robot stable and controllable.
   </description>
 
   <maintainer email="7sell@informatik.uni-hamburg.de">Finn-Thorben Sell</maintainer>
@@ -34,5 +35,6 @@
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>
+      <language>cpp</language>
   </export>
 </package>

--- a/bitbots_quintic_walk/CMakeLists.txt
+++ b/bitbots_quintic_walk/CMakeLists.txt
@@ -31,6 +31,7 @@ find_package(catkin REQUIRED COMPONENTS
         geometry_msgs
         moveit_ros_robot_interaction
         bitbots_msgs
+        bitbots_docs
         )
 
 find_package(Eigen3 REQUIRED)
@@ -81,3 +82,5 @@ add_executable(WalkNode ${SOURCES})
 add_dependencies(WalkNode ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS} ${PROJECT_NAME}_gencfg)
 
 target_link_libraries(WalkNode ${catkin_LIBRARIES} ${CODE_LIBRARIES})
+
+enable_bitbots_docs()

--- a/bitbots_quintic_walk/doc/mainpage.md
+++ b/bitbots_quintic_walk/doc/mainpage.md
@@ -1,5 +1,0 @@
-\mainpage
-\htmlinclude manifest.html
-<a href="./index-msg.html">Msg/Src Documentation</a>
-
-This ROS package includes a node which provides the base footprint frame for any humanoid robot following REP - 120.

--- a/bitbots_quintic_walk/package.xml
+++ b/bitbots_quintic_walk/package.xml
@@ -39,6 +39,8 @@
   <test_depend>plotjuggler</test_depend>
   <test_depend>bitbots_odometry</test_depend>
 
+  <depend>bitbots_docs</depend>
+
   <export>
     <bitbots_documentation>
       <status>tested_integration</status>

--- a/bitbots_splines/CMakeLists.txt
+++ b/bitbots_splines/CMakeLists.txt
@@ -9,7 +9,9 @@ find_package(catkin REQUIRED COMPONENTS
         std_msgs
         eigen_conversions
         bio_ik
+        bitbots_docs
         )
+
 find_package(Eigen3 REQUIRED)
 find_package(PkgConfig REQUIRED)
 
@@ -62,3 +64,5 @@ target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 install(DIRECTORY include/${PROJECT_NAME}/ DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
 install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+
+enable_bitbots_docs()

--- a/bitbots_splines/doc/mainpage.md
+++ b/bitbots_splines/doc/mainpage.md
@@ -1,5 +1,0 @@
-\mainpage
-\htmlinclude manifest.html
-<a href="./index-msg.html">Msg/Src Documentation</a>
-
-This ROS package includes a node which provides the base footprint frame for any humanoid robot following REP - 120.

--- a/bitbots_splines/package.xml
+++ b/bitbots_splines/package.xml
@@ -22,6 +22,8 @@
   <depend>eigen_conversions</depend>
   <depend>bio_ik</depend>
 
+  <depend>bitbots_docs</depend>
+
   <export>
     <bitbots_documentation>
       <status>stable</status>


### PR DESCRIPTION
With this change we switch to using the documentation system provided through the `bitbots_docs` package.
It provides an easy and automatic way of generating sphinx documentation from c++ and python code