### PR TITLE
dynamic_kick: directly use trunk pose for stabilizing

### DIFF
--- a/bitbots_dynamic_kick/cfg/bitbots_dynamic_kick_params.cfg
+++ b/bitbots_dynamic_kick/cfg/bitbots_dynamic_kick_params.cfg
@@ -24,6 +24,9 @@ group_engine_distances.add("foot_distance", double_t, 2,
 group_engine_distances.add("kick_windup_distance", double_t, 2,
                            "How far away from the ball to stop and perform the actual (fast) kick movement [m]",
                            0.2, min=0, max=2)
+group_engine_distances.add("trunk_height", double_t, 4,
+                           "Height of the trunk [m]",
+                           0.4, min=0, max=0.6)
 
 group_engine_timings = group_engine.add_group("Timings")
 group_engine_timings.add("move_trunk_time", double_t, 3,
@@ -56,29 +59,14 @@ group_engine_decisions.add("choose_foot_corridor_width", double_t, 3,
                            0.4, min=0)
 
 group_stabilizing = gen.add_group("Stabilizer", type="tab")
-group_stabilizing.add("stabilizing", bool_t, 4,
-                      "Whether to use automatic stabilizing or not",
-                      True)
 
 group_stabilizing_bioik = group_stabilizing.add_group("BioIk weights")
-group_stabilizing_bioik.add("minimal_displacement", bool_t, 4,
-                            "Try to stabilize with as little movement as possible",
-                            True)
-group_stabilizing_bioik.add("trunk_height", double_t, 4,
-                            "Height of the trunk [m]",
-                            0.4, min=0, max=0.6)
-group_stabilizing_bioik.add("stabilizing_weight", double_t, 4,
-                            "How important bio_ik should regard keeping the robot in a stable position [0:1]",
-                            1.0, min=0, max=1)
 group_stabilizing_bioik.add("flying_weight", double_t, 4,
                             "How important bio_ik should regard the flying foots position [0:1]",
                             0.85, min=0, max=1)
-group_stabilizing_bioik.add("trunk_orientation_weight", double_t, 4,
-                            "How important bio_ik should regard keeping the trunk orientation [0:1]",
-                            0.24, min=0, max=1)
-group_stabilizing_bioik.add("trunk_height_weight", double_t, 4,
-                            "How important bio_ik should regard keeping the trunk height [0:1]",
-                            0.3, min=0, max=1)
+group_stabilizing_bioik.add("trunk_weight", double_t, 4,
+                            "How important bio_ik should regard the position of the trunk [0:1]",
+                            0.85, min=0, max=1)
 
 group_stabilizing_cop = group_stabilizing.add_group("CenterOfPressure regulation")
 group_stabilizing_cop.add("use_center_of_pressure", bool_t, 4,

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_engine.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_engine.h
@@ -21,6 +21,7 @@ struct KickParams {
   double foot_rise;
   double foot_distance;
   double kick_windup_distance;
+  double trunk_height;
 
   double move_trunk_time = 1;
   double raise_foot_time = 1;
@@ -111,7 +112,8 @@ class KickEngine : public bitbots_splines::AbstractEngine<KickGoals, KickPositio
 
   int getPercentDone() const override;
 
-  bitbots_splines::PoseSpline getSplines() const ;
+  bitbots_splines::PoseSpline getFlyingSplines() const ;
+  bitbots_splines::PoseSpline getTrunkSplines() const ;
 
   void setParams(KickParams params);
 
@@ -125,8 +127,7 @@ class KickEngine : public bitbots_splines::AbstractEngine<KickGoals, KickPositio
   tf2::Quaternion kick_direction_;
   float kick_speed_;
   bool is_left_kick_;
-  bitbots_splines::PositionSpline support_point_spline_;
-  bitbots_splines::PoseSpline flying_foot_spline_;
+  bitbots_splines::PoseSpline flying_foot_spline_, trunk_spline_;
   KickParams params_;
   PhaseTimings phase_timings_;
   tf2::Vector3 windup_point_;
@@ -139,7 +140,7 @@ class KickEngine : public bitbots_splines::AbstractEngine<KickGoals, KickPositio
    *
    *  @param flying_foot_pose Current pose of the foot which is supposed to be the flying/kicking one
    */
-  void calcSplines(const geometry_msgs::Pose &flying_foot_pose);
+  void calcSplines(const geometry_msgs::Pose &flying_foot_pose, const geometry_msgs::Transform &trunk_pose);
 
   /**
    *  Calculate the point from which to perform the final kicking movement
@@ -164,7 +165,8 @@ class KickEngine : public bitbots_splines::AbstractEngine<KickGoals, KickPositio
                              const geometry_msgs::Vector3 &ball_position,
                              const geometry_msgs::Quaternion &kick_direction);
 
-  geometry_msgs::PoseStamped getCurrentPose(bitbots_splines::PoseSpline spline);
+  geometry_msgs::Transform getTrunkPose();
+
 
   /**
    * Calculate the yaw of the kicking foot, so that it is turned

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_utils.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_utils.h
@@ -11,8 +11,8 @@ namespace bitbots_dynamic_kick {
 
 struct KickPositions {
   bool is_left_kick = true;
-  geometry_msgs::Point support_point;
-  geometry_msgs::PoseStamped flying_foot_pose;
+  geometry_msgs::Pose trunk_pose;
+  geometry_msgs::Pose flying_foot_pose;
   bool cop_support_point = false;
 };
 

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/stabilizer.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/stabilizer.h
@@ -29,35 +29,23 @@ class Stabilizer :
   override;
   void reset()
   override;
-  void useStabilizing(bool use);
-  void useMinimalDisplacement(bool use);
   void useCop(bool use);
-  void setTrunkHeight(double height);
-  void setStabilizingWeight(double weight);
   void setFlyingWeight(double weight);
-  void setTrunkOrientationWeight(double weight);
-  void setTrunkHeightWeight(double weight);
+  void setTrunkWeight(double weight);
   void setPFactor(double factor_x, double factor_y);
   void setIFactor(double factor_x, double factor_y);
   void setDFactor(double factor_x, double factor_y);
-  tf2::Vector3 getStabilizingTarget() const;
   void setRobotModel(moveit::core::RobotModelPtr model);
  private:
   moveit::core::RobotModelPtr kinematic_model_;
-  tf2::Vector3 stabilizing_target_;
   double cop_x_error_sum_;
   double cop_y_error_sum_;
   double cop_x_error_;
   double cop_y_error_;
 
-  bool use_stabilizing_;
-  bool use_minimal_displacement_;
   bool use_cop_;
-  double trunk_height_;
-  double stabilizing_weight_;
   double flying_weight_;
-  double trunk_orientation_weight_;
-  double trunk_height_weight_;
+  double trunk_weight_;
   double p_x_factor_;
   double p_y_factor_;
   double i_x_factor_;

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/visualizer.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/visualizer.h
@@ -39,16 +39,16 @@ class Visualizer : bitbots_splines::AbstractVisualizer {
 
   void displayFlyingSplines(bitbots_splines::PoseSpline splines, const std::string &support_foot_frame);
 
-  void displayWindupPoint(const tf2::Vector3 &kick_windup_point, const std::string &support_foot_frame);
+  void displayTrunkSplines(bitbots_splines::PoseSpline splines);
 
-  void displayStabilizingPoint(const tf2::Vector3 &kick_windup_point, const std::string &support_foot_frame);
+  void displayWindupPoint(const tf2::Vector3 &kick_windup_point, const std::string &support_foot_frame);
 
  private:
   ros::NodeHandle node_handle_;
   ros::Publisher goal_publisher_;
-  ros::Publisher spline_publisher_;
+  ros::Publisher foot_spline_publisher_;
+  ros::Publisher trunk_spline_publisher_;
   ros::Publisher windup_publisher_;
-  ros::Publisher stabilizing_publisher_;
   std::string base_topic_;
   const std::string marker_ns_ = "bitbots_dynamic_kick";
   VisualizationParams params_;

--- a/bitbots_dynamic_kick/package.xml
+++ b/bitbots_dynamic_kick/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_dynamic_kick</name>
-  <version>0.0.0</version>
+  <version>0.1.0</version>
   <description>
 	  The bitbots_dynamic_kick package implements a kick which is not based on keyframe animations.
 	  Instead it aims to dynamically reach it's movement goal while keeping the robot stable and controllable.

--- a/bitbots_dynamic_kick/src/kick_node.cpp
+++ b/bitbots_dynamic_kick/src/kick_node.cpp
@@ -29,14 +29,14 @@ KickNode::KickNode() :
 }
 
 void KickNode::copLCallback(const geometry_msgs::PointStamped &cop) {
-  if (cop.header.frame_id!="l_sole") {
+  if (cop.header.frame_id != "l_sole") {
     ROS_ERROR_STREAM("cop_l not in l_sole frame! Stabilizing will not work.");
   }
   stabilizer_.cop_left = cop.point;
 }
 
 void KickNode::copRCallback(const geometry_msgs::PointStamped &cop) {
-  if (cop.header.frame_id!="r_sole") {
+  if (cop.header.frame_id != "r_sole") {
     ROS_ERROR_STREAM("cop_r not in r_sole frame! Stabilizing will not work.");
   }
   stabilizer_.cop_right = cop.point;
@@ -49,6 +49,7 @@ void KickNode::reconfigureCallback(bitbots_dynamic_kick::DynamicKickConfig &conf
   params.foot_rise = config.foot_rise;
   params.foot_distance = config.foot_distance;
   params.kick_windup_distance = config.kick_windup_distance;
+  params.trunk_height = config.trunk_height;
   params.move_trunk_time = config.move_trunk_time;
   params.raise_foot_time = config.raise_foot_time;
   params.move_to_ball_time = config.move_to_ball_time;
@@ -61,14 +62,9 @@ void KickNode::reconfigureCallback(bitbots_dynamic_kick::DynamicKickConfig &conf
   params.choose_foot_corridor_width = config.choose_foot_corridor_width;
   engine_.setParams(params);
 
-  stabilizer_.useMinimalDisplacement(config.minimal_displacement);
-  stabilizer_.useStabilizing(config.stabilizing);
   stabilizer_.useCop(config.use_center_of_pressure);
-  stabilizer_.setTrunkHeight(config.trunk_height);
-  stabilizer_.setStabilizingWeight(config.stabilizing_weight);
+  stabilizer_.setTrunkWeight(config.trunk_weight);
   stabilizer_.setFlyingWeight(config.flying_weight);
-  stabilizer_.setTrunkOrientationWeight(config.trunk_orientation_weight);
-  stabilizer_.setTrunkHeightWeight(config.trunk_height_weight);
   stabilizer_.setPFactor(config.stabilizing_p_x, config.stabilizing_p_y);
   stabilizer_.setIFactor(config.stabilizing_i_x, config.stabilizing_i_y);
   stabilizer_.setDFactor(config.stabilizing_d_x, config.stabilizing_d_y);
@@ -119,7 +115,8 @@ void KickNode::executeCb(const bitbots_msgs::KickGoalConstPtr &goal) {
   stabilizer_.reset();
   ik_.reset();
   visualizer_.displayWindupPoint(engine_.getWindupPoint(), (engine_.isLeftKick()) ? "r_sole" : "l_sole");
-  visualizer_.displayFlyingSplines(engine_.getSplines(), (engine_.isLeftKick()) ? "r_sole" : "l_sole");
+  visualizer_.displayFlyingSplines(engine_.getFlyingSplines(), (engine_.isLeftKick()) ? "r_sole" : "l_sole");
+  visualizer_.displayTrunkSplines(engine_.getTrunkSplines());
   loopEngine();
 
   /* Figure out the reason why loopEngine() returned and act accordingly */
@@ -163,11 +160,9 @@ std::pair<geometry_msgs::Pose, geometry_msgs::Pose> KickNode::getFootPoses() {
 void KickNode::loopEngine() {
   /* Do the loop as long as nothing cancels it */
   while (server_.isActive() && !server_.isPreemptRequested()) {
-    KickPositions positions = engine_.update(1.0/engine_rate_);
+    KickPositions positions = engine_.update(1.0 / engine_rate_);
     // TODO: should positions be an std::optional? how are errors represented?
     std::unique_ptr<bio_ik::BioIKKinematicsQueryOptions> ik_goals = stabilizer_.stabilize(positions);
-    visualizer_
-        .displayStabilizingPoint(stabilizer_.getStabilizingTarget(), positions.is_left_kick ? "r_sole" : "l_sole");
     bitbots_splines::JointGoals motor_goals = ik_.calculate(std::move(ik_goals));
 
     bitbots_msgs::KickFeedback feedback;
@@ -179,7 +174,7 @@ void KickNode::loopEngine() {
 
     publishSupportFoot(engine_.isLeftKick());
 
-    if (feedback.percent_done==100) {
+    if (feedback.percent_done == 100) {
       break;
     }
 

--- a/bitbots_dynamic_kick/src/stabilizer.cpp
+++ b/bitbots_dynamic_kick/src/stabilizer.cpp
@@ -21,7 +21,7 @@ std::unique_ptr<bio_ik::BioIKKinematicsQueryOptions> Stabilizer::stabilize(const
   ik_options->replace = true;
   ik_options->return_approximate_solution = true;
 
-  tf2::Vector3 stabilizing_target;
+  tf2::Transform trunk_goal;
   if (positions.cop_support_point && use_cop_) {
     /* calculate stabilizing target from center of pressure
      * the cop is in corresponding sole frame
@@ -34,30 +34,43 @@ std::unique_ptr<bio_ik::BioIKKinematicsQueryOptions> Stabilizer::stabilize(const
       cop_x = cop_left.x;
       cop_y = cop_left.y;
     }
-    cop_x_error = cop_x - positions.support_point.x;
-    cop_y_error = cop_y - positions.support_point.y;
+    cop_x_error = cop_x - positions.trunk_pose.position.x;
+    cop_y_error = cop_y - positions.trunk_pose.position.y;
     cop_x_error_sum_ += cop_x_error;
     cop_y_error_sum_ += cop_y_error;
-    stabilizing_target.setX(positions.support_point.x - cop_x*p_x_factor_ - i_x_factor_*cop_x_error_sum_
-                                - d_x_factor_*(cop_x_error - cop_x_error_));
-    stabilizing_target.setY(positions.support_point.y - cop_y*p_y_factor_ - i_y_factor_*cop_y_error_sum_
-                                - d_y_factor_*(cop_y_error - cop_y_error_));
+    double x = positions.trunk_pose.position.x - cop_x*p_x_factor_ - i_x_factor_*cop_x_error_sum_
+                                - d_x_factor_*(cop_x_error - cop_x_error_);
+    double y = positions.trunk_pose.position.y - cop_y*p_y_factor_ - i_y_factor_*cop_y_error_sum_
+                                - d_y_factor_*(cop_y_error - cop_y_error_);
     cop_x_error_ = cop_x_error;
     cop_y_error_ = cop_y_error;
-    stabilizing_target.setZ(0);
+    /* Do not use control for height and rotation */
+    trunk_goal.setOrigin({x, y, positions.trunk_pose.position.z});
+    trunk_goal.setRotation({positions.trunk_pose.orientation.x, positions.trunk_pose.orientation.y,
+                            positions.trunk_pose.orientation.z, positions.trunk_pose.orientation.w});
   } else {
-    stabilizing_target = {positions.support_point.x, positions.support_point.y, positions.support_point.z};
+    tf2::convert(positions.trunk_pose, trunk_goal);
   }
-  stabilizing_target_ = stabilizing_target;
+  auto *bio_ik_trunk_goal = new ReferencePoseGoal();
+  bio_ik_trunk_goal->setWeight(trunk_weight_);
+  bio_ik_trunk_goal->setPosition(trunk_goal.getOrigin());
+  bio_ik_trunk_goal->setOrientation(trunk_goal.getRotation());
+  bio_ik_trunk_goal->setLinkName("base_link");
+  if (positions.is_left_kick) {
+    bio_ik_trunk_goal->setReferenceLinkName("r_sole");
+  } else {
+    bio_ik_trunk_goal->setReferenceLinkName("l_sole");
+  }
+  ik_options->goals.emplace_back(bio_ik_trunk_goal);
 
   tf2::Transform flying_foot_goal;
-  flying_foot_goal.setOrigin({positions.flying_foot_pose.pose.position.x,
-                              positions.flying_foot_pose.pose.position.y,
-                              positions.flying_foot_pose.pose.position.z});
-  flying_foot_goal.setRotation({positions.flying_foot_pose.pose.orientation.x,
-                                positions.flying_foot_pose.pose.orientation.y,
-                                positions.flying_foot_pose.pose.orientation.z,
-                                positions.flying_foot_pose.pose.orientation.w});
+  flying_foot_goal.setOrigin({positions.flying_foot_pose.position.x,
+                              positions.flying_foot_pose.position.y,
+                              positions.flying_foot_pose.position.z});
+  flying_foot_goal.setRotation({positions.flying_foot_pose.orientation.x,
+                                positions.flying_foot_pose.orientation.y,
+                                positions.flying_foot_pose.orientation.z,
+                                positions.flying_foot_pose.orientation.w});
 
 
   /* construct the bio_ik Pose object which tells bio_ik what we want to achieve */
@@ -73,79 +86,20 @@ std::unique_ptr<bio_ik::BioIKKinematicsQueryOptions> Stabilizer::stabilize(const
   }
   bio_ik_flying_foot_goal->setWeight(flying_weight_);
 
-  auto *trunk_orientation_goal = new ReferenceOrientationGoal();
-  tf2::Quaternion trunk_orientation;
-  trunk_orientation.setRPY(0, 0.2, 0);
-  trunk_orientation_goal->setOrientation(trunk_orientation);
-  trunk_orientation_goal->setLinkName("base_link");
-  if (positions.is_left_kick) {
-    trunk_orientation_goal->setReferenceLinkName("r_sole");
-  } else {
-    trunk_orientation_goal->setReferenceLinkName("l_sole");
-  }
-  trunk_orientation_goal->setWeight(trunk_orientation_weight_);
-  ik_options->goals.emplace_back(trunk_orientation_goal);
-
-  auto *trunk_height_goal = new ReferenceHeightGoal();
-  trunk_height_goal->setHeight(trunk_height_);
-  trunk_height_goal->setWeight(trunk_height_weight_);
-  trunk_height_goal->setLinkName("base_link");
-  if (positions.is_left_kick) {
-    trunk_height_goal->setReferenceLinkName("r_sole");
-  } else {
-    trunk_height_goal->setReferenceLinkName("l_sole");
-  }
-  ik_options->goals.emplace_back(trunk_height_goal);
-
-  auto *bio_ik_balancing_context = new DynamicBalancingContext(kinematic_model_);
-  auto *bio_ik_balance_goal =
-      new DynamicBalancingGoal(bio_ik_balancing_context, stabilizing_target, stabilizing_weight_);
-  if (positions.is_left_kick) {
-    bio_ik_balance_goal->setReferenceLink("r_sole");
-  } else {
-    bio_ik_balance_goal->setReferenceLink("l_sole");
-  }
-
   ik_options->goals.emplace_back(bio_ik_flying_foot_goal);
-  if (use_stabilizing_) {
-    ik_options->goals.emplace_back(bio_ik_balance_goal);
-  }
-  if (use_minimal_displacement_) {
-    ik_options->goals.emplace_back(new bio_ik::MinimalDisplacementGoal());
-  }
   return std::move(ik_options);
-}
-
-void Stabilizer::useStabilizing(bool use) {
-  use_stabilizing_ = use;
-}
-
-void Stabilizer::useMinimalDisplacement(bool use) {
-  use_minimal_displacement_ = use;
 }
 
 void Stabilizer::useCop(bool use) {
   use_cop_ = use;
 }
 
-void Stabilizer::setTrunkHeight(double height) {
-  trunk_height_ = height;
-}
-
-void Stabilizer::setStabilizingWeight(double weight) {
-  stabilizing_weight_ = weight;
-}
-
 void Stabilizer::setFlyingWeight(double weight) {
   flying_weight_ = weight;
 }
 
-void Stabilizer::setTrunkOrientationWeight(double weight) {
-  trunk_orientation_weight_ = weight;
-}
-
-void Stabilizer::setTrunkHeightWeight(double weight) {
-  trunk_height_weight_ = weight;
+void Stabilizer::setTrunkWeight(double weight) {
+  trunk_weight_ = weight;
 }
 
 void Stabilizer::setPFactor(double factor_x, double factor_y) {
@@ -161,10 +115,6 @@ void Stabilizer::setIFactor(double factor_x, double factor_y) {
 void Stabilizer::setDFactor(double factor_x, double factor_y) {
   d_x_factor_ = factor_x;
   d_y_factor_ = factor_y;
-}
-
-tf2::Vector3 Stabilizer::getStabilizingTarget() const {
-  return stabilizing_target_;
 }
 
 void Stabilizer::setRobotModel(moveit::core::RobotModelPtr model) {


### PR DESCRIPTION
The DynamicBalancingGoal for BioIK prefers more stable poses but cannot control only a subset of the joints. Therefore, the flying foot is often placed very close to the support leg to be more stable. This results in a bad execution of the kick trajectory. Therefore, the DynamicBalancingGoal is replaced by a PoseGoal for the `base_link`. This is not exactly the center of mass but should be very close to it. Further control happens via the PID controller for the foot pressure sensors.

## Necessary checks
- [x] Update package version
- [x] Run linters
- [x] Run `catkin build`
- [ ] Write documentation
- [x] Test on your machine
- [x] Test on the robot
