### PR TITLE
Fix some memory/pointer problems

### DIFF
--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_ik.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_ik.h
@@ -17,7 +17,7 @@ class KickIK : public bitbots_splines::AbstractIK {
  private:
   robot_state::RobotStatePtr m_goal_state_;
   planning_scene::PlanningScenePtr m_planning_scene_;
-  moveit::core::JointModelGroupPtr m_legs_joints_group_;
+  robot_model::JointModelGroup *m_legs_joints_group_;
 };
 }
 

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_node.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_node.h
@@ -60,6 +60,7 @@ class KickNode {
   int engine_rate_;
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener listener_;
+  robot_model_loader::RobotModelLoader robot_model_loader_;
 
   /**
    * Do main loop in which KickEngine::update() gets called repeatedly.

--- a/bitbots_dynamic_kick/src/kick_ik.cpp
+++ b/bitbots_dynamic_kick/src/kick_ik.cpp
@@ -5,7 +5,7 @@ namespace bitbots_dynamic_kick {
 
 void KickIK::init(moveit::core::RobotModelPtr kinematic_model) {
   /* Extract joint groups from kinematics model */
-  m_legs_joints_group_.reset(kinematic_model->getJointModelGroup("Legs"));
+  m_legs_joints_group_ = kinematic_model->getJointModelGroup("Legs");
 
   /* Reset kinematic goal to default */
   m_goal_state_.reset(new robot_state::RobotState(kinematic_model));
@@ -28,7 +28,7 @@ void KickIK::reset() {
 
 bitbots_splines::JointGoals KickIK::calculate(const std::unique_ptr<bio_ik::BioIKKinematicsQueryOptions> ik_goals) {
   double bio_ik_timeout = 0.01;
-  bool success = m_goal_state_->setFromIK(m_legs_joints_group_.get(),
+  bool success = m_goal_state_->setFromIK(m_legs_joints_group_,
                                           EigenSTL::vector_Isometry3d(),
                                           std::vector<std::string>(),
                                           bio_ik_timeout,
@@ -48,7 +48,7 @@ bitbots_splines::JointGoals KickIK::calculate(const std::unique_ptr<bio_ik::BioI
     /* retrieve joint names and associated positions from  */
     std::vector<std::string> joint_names = m_legs_joints_group_->getActiveJointModelNames();
     std::vector<double> joint_goals;
-    m_goal_state_->copyJointGroupPositions(m_legs_joints_group_.get(), joint_goals);
+    m_goal_state_->copyJointGroupPositions(m_legs_joints_group_, joint_goals);
 
     /* construct result object */
     bitbots_splines::JointGoals result;

--- a/bitbots_dynamic_kick/src/kick_node.cpp
+++ b/bitbots_dynamic_kick/src/kick_node.cpp
@@ -8,12 +8,12 @@ KickNode::KickNode() :
     server_(node_handle_, "dynamic_kick", boost::bind(&KickNode::executeCb, this, _1), false),
     listener_(tf_buffer_),
     engine_(),
-    visualizer_("/debug/dynamic_kick") {
+    visualizer_("/debug/dynamic_kick"),
+    robot_model_loader_("/robot_description", false) {
 
   /* load MoveIt! model */
-  robot_model_loader::RobotModelLoader robot_model_loader("/robot_description", false);
-  robot_model_loader.loadKinematicsSolvers(std::make_shared<kinematics_plugin_loader::KinematicsPluginLoader>());
-  robot_model::RobotModelPtr kinematic_model = robot_model_loader.getModel();
+  robot_model_loader_.loadKinematicsSolvers(std::make_shared<kinematics_plugin_loader::KinematicsPluginLoader>());
+  robot_model::RobotModelPtr kinematic_model = robot_model_loader_.getModel();
   if (!kinematic_model) {
     ROS_FATAL("No robot model loaded, killing dynamic kick.");
     exit(1);

--- a/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_ik.h
+++ b/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_ik.h
@@ -16,7 +16,7 @@ class WalkIK : public bitbots_splines::AbstractIK {
 
  private:
   robot_state::RobotStatePtr goal_state_;
-  moveit::core::JointModelGroupPtr legs_joints_group_;
+  const moveit::core::JointModelGroup *legs_joints_group_;
 
   // IK solver
   bitbots_ik::BioIKSolver bio_ik_solver_;

--- a/bitbots_quintic_walk/src/walk_ik.cpp
+++ b/bitbots_quintic_walk/src/walk_ik.cpp
@@ -5,7 +5,7 @@ namespace bitbots_quintic_walk {
 WalkIK::WalkIK() : bio_ik_timeout_(0.01) {}
 
 void WalkIK::init(moveit::core::RobotModelPtr kinematic_model) {
-  legs_joints_group_.reset(kinematic_model->getJointModelGroup("Legs"));
+  legs_joints_group_ = kinematic_model->getJointModelGroup("Legs");
   goal_state_.reset(new robot_state::RobotState(kinematic_model));
   goal_state_->setToDefaultValues();
 
@@ -13,7 +13,7 @@ void WalkIK::init(moveit::core::RobotModelPtr kinematic_model) {
 }
 
 bitbots_splines::JointGoals WalkIK::calculate(const std::unique_ptr<bio_ik::BioIKKinematicsQueryOptions> ik_goals) {
-  bool success = goal_state_->setFromIK(legs_joints_group_.get(),
+  bool success = goal_state_->setFromIK(legs_joints_group_,
                                         EigenSTL::vector_Isometry3d(),
                                         std::vector<std::string>(),
                                         bio_ik_timeout_,
@@ -23,7 +23,7 @@ bitbots_splines::JointGoals WalkIK::calculate(const std::unique_ptr<bio_ik::BioI
     /* retrieve joint names and associated positions from  */
     std::vector<std::string> joint_names = legs_joints_group_->getActiveJointModelNames();
     std::vector<double> joint_goals;
-    goal_state_->copyJointGroupPositions(legs_joints_group_.get(), joint_goals);
+    goal_state_->copyJointGroupPositions(legs_joints_group_, joint_goals);
 
     /* construct result object */
     bitbots_splines::JointGoals result;


### PR DESCRIPTION
The first commit removes the SEVERE WARNING in the kick that existed because the RobotModelLoader must outlive the loaded RobotModel. The second commit fixes the JointModelGroup pointers in both kick and walking that were shared pointers instead of regular (c style) pointers that are returned by moveit.