### PR TITLE
splines: name splines access methods like in pose spline

### DIFF
--- a/bitbots_splines/include/bitbots_splines/position_spline.h
+++ b/bitbots_splines/include/bitbots_splines/position_spline.h
@@ -16,9 +16,9 @@ class PositionSpline {
   tf2::Vector3 getVel(double time);
   tf2::Vector3 getAcc(double time);
 
-  SmoothSpline *getSplineX();
-  SmoothSpline *getSplineY();
-  SmoothSpline *getSplineZ();
+  SmoothSpline *x();
+  SmoothSpline *y();
+  SmoothSpline *z();
 
  private:
   SmoothSpline x_;

--- a/bitbots_splines/src/Spline/position_spline.cpp
+++ b/bitbots_splines/src/Spline/position_spline.cpp
@@ -36,15 +36,15 @@ tf2::Vector3 PositionSpline::getAcc(double time){
 }
 
 
-SmoothSpline *PositionSpline::getSplineX(){
+SmoothSpline *PositionSpline::x(){
   return &x_;
 }
 
-SmoothSpline *PositionSpline::getSplineY(){
+SmoothSpline *PositionSpline::y(){
   return &y_;
 }
 
-SmoothSpline *PositionSpline::getSplineZ(){
+SmoothSpline *PositionSpline::z(){
   return &z_;
 }
 


### PR DESCRIPTION
Currently, the spline access methods in the PoseSpline are named `x()`, `y()`, etc. while these methods in the PositionSpline are named `getSplineX()`, etc. This pull requests unifies these names.
