### PR TITLE
dynamic_kick: fix crashes due to invalid tf transformations

### DIFF
--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_engine.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_engine.h
@@ -11,6 +11,7 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2/convert.h>
 #include <tf2/utils.h>
+#include <tf2/exceptions.h>
 #include "stabilizer.h"
 #include "visualizer.h"
 
@@ -85,6 +86,8 @@ class KickEngine : public bitbots_splines::AbstractEngine<KickGoals, KickPositio
    * @param kick_speed Speed with which to kick the ball
    * @param r_foot_pose Current pose of right foot in l_sole frame
    * @param l_foot_pose Current pose of left foot in r_sole frame
+   *
+   * @throws tf2::TransformException when goal cannot be converted into needed tf frames
    */
   void setGoals(const KickGoals &goals) override;
 
@@ -158,8 +161,10 @@ class KickEngine : public bitbots_splines::AbstractEngine<KickGoals, KickPositio
    *
    * @param header Definition of frame and time in which the goals were published
    * @param ball_position Position where the ball is currently located
-   * @param kick_movement Direction into which the ball should be kicked
+   * @param kick_direction Direction into which the ball should be kicked
    * @return Whether the resulting kick should be performed with the left foot
+   *
+   * @throws tf2::TransformException when ball_position and kick_direction cannot be converted into base_footprint frame
    */
   bool calcIsLeftFootKicking(const std_msgs::Header &header,
                              const geometry_msgs::Vector3 &ball_position,
@@ -180,6 +185,8 @@ class KickEngine : public bitbots_splines::AbstractEngine<KickGoals, KickPositio
    * @param ball_position Position of the ball
    * @param kick_direction Direction in which to kick the ball
    * @return pair of (transformed_pose, transformed_direction)
+   *
+   * @throws tf2::TransformException when goal cannot be transformed into support_foot_frame
    */
   std::optional<std::pair<geometry_msgs::Point, geometry_msgs::Quaternion>> transformGoal(
       const std::string &support_foot_frame,

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_engine.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_engine.h
@@ -188,7 +188,7 @@ class KickEngine : public bitbots_splines::AbstractEngine<KickGoals, KickPositio
    *
    * @throws tf2::TransformException when goal cannot be transformed into support_foot_frame
    */
-  std::optional<std::pair<geometry_msgs::Point, geometry_msgs::Quaternion>> transformGoal(
+  std::pair<geometry_msgs::Point, geometry_msgs::Quaternion> transformGoal(
       const std::string &support_foot_frame,
       const std_msgs::Header &header,
       const geometry_msgs::Vector3 &ball_position,

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_node.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_node.h
@@ -72,8 +72,10 @@ class KickNode {
    * Retrieve current feet_positions in base_link frame
    *
    * @return The pair of (right foot, left foot) poses if transformation was successfull
+   *
+   * @throws tf2::TransformException if feet positions cannot be retrieved
    */
-  std::optional<std::pair<geometry_msgs::Pose, geometry_msgs::Pose>> getFootPoses();
+  std::pair<geometry_msgs::Pose, geometry_msgs::Pose> getFootPoses();
 
   /**
    * Publish the current support_foot so that a correct base_footprint can be calculated

--- a/bitbots_dynamic_kick/src/kick_engine.cpp
+++ b/bitbots_dynamic_kick/src/kick_engine.cpp
@@ -19,9 +19,8 @@ void KickEngine::setGoals(const KickGoals &goals) {
   // TODO Internal state is dirty when goal transformation fails
 
   /* Save given goals because we reuse them later */
-  auto transformed_goal = transformGoal((is_left_kick_) ? "r_sole" : "l_sole", goals.header, goals.ball_position,
-                                        goals.kick_direction);
-  // TODO: handle when goal was not transformed
+  auto transformed_goal = transformGoal((is_left_kick_) ? "r_sole" : "l_sole",
+                                        goals.header, goals.ball_position, goals.kick_direction);
   tf2::convert(transformed_goal->first, ball_position_);
   tf2::convert(transformed_goal->second, kick_direction_);
   kick_direction_.normalize();

--- a/bitbots_dynamic_kick/src/kick_engine.cpp
+++ b/bitbots_dynamic_kick/src/kick_engine.cpp
@@ -21,8 +21,8 @@ void KickEngine::setGoals(const KickGoals &goals) {
   /* Save given goals because we reuse them later */
   auto transformed_goal = transformGoal((is_left_kick_) ? "r_sole" : "l_sole",
                                         goals.header, goals.ball_position, goals.kick_direction);
-  tf2::convert(transformed_goal->first, ball_position_);
-  tf2::convert(transformed_goal->second, kick_direction_);
+  tf2::convert(transformed_goal.first, ball_position_);
+  tf2::convert(transformed_goal.second, kick_direction_);
   kick_direction_.normalize();
   kick_speed_ = goals.kick_speed;
 
@@ -218,7 +218,7 @@ void KickEngine::initTrajectories() {
   flying_trajectories_->add("yaw");
 }
 
-std::optional<std::pair<geometry_msgs::Point, geometry_msgs::Quaternion>> KickEngine::transformGoal(
+std::pair<geometry_msgs::Point, geometry_msgs::Quaternion> KickEngine::transformGoal(
     const std::string &support_foot_frame,
     const std_msgs::Header &header,
     const geometry_msgs::Vector3 &ball_position,

--- a/bitbots_dynamic_kick/src/kick_node.cpp
+++ b/bitbots_dynamic_kick/src/kick_node.cpp
@@ -84,60 +84,61 @@ void KickNode::executeCb(const bitbots_msgs::KickGoalConstPtr &goal) {
   ROS_INFO("Accepted new goal");
   engine_.reset();
 
-  if (auto foot_poses = getFootPoses()) {
-
-    visualizer_.displayReceivedGoal(goal);
-
-    /* Set engines goal and start calculating */
-    KickGoals goals;
-    goals.ball_position = goal->ball_position;
-    goals.header = goal->header;
-    goals.kick_direction = goal->kick_direction;
-    goals.kick_speed = goal->kick_speed;
-    goals.r_foot_pose = foot_poses->first;
-    goals.l_foot_pose = foot_poses->second;
-
-    try {
-      engine_.setGoals(goals);
-    }
-    catch (tf2::TransformException &e) {
-      ROS_ERROR_STREAM("Could not transform goal to needed tf frames: " << e.what());
-      bitbots_msgs::KickResult result;
-      result.result = bitbots_msgs::KickResult::REJECTED;
-      server_.setAborted(result, "Could not transform goal to needed tf frames");
-      return;
-    }
-
-    stabilizer_.reset();
-    ik_.reset();
-    visualizer_.displayWindupPoint(engine_.getWindupPoint(), (engine_.isLeftKick()) ? "r_sole" : "l_sole");
-    visualizer_.displayFlyingSplines(engine_.getSplines(), (engine_.isLeftKick()) ? "r_sole" : "l_sole");
-    loopEngine();
-
-    /* Figure out the reason why loopEngine() returned and act accordingly */
-    if (server_.isPreemptRequested()) {
-      /* Confirm that we canceled the previous goal */
-      ROS_INFO("Cancelled old goal");
-      bitbots_msgs::KickResult result;
-      result.result = bitbots_msgs::KickResult::ABORTED;
-      server_.setPreempted(result);
-    } else {
-      /* Publish results */
-      ROS_INFO("Done kicking ball");
-      bitbots_msgs::KickResult result;
-      result.result = bitbots_msgs::KickResult::SUCCESS;
-      server_.setSucceeded(result);
-    }
-
-  } else {
+  std::pair<geometry_msgs::Pose, geometry_msgs::Pose> foot_poses;
+  try {
+    foot_poses = getFootPoses();
+  } catch (tf2::TransformException &e) {
     ROS_ERROR("Could not process goal because current feet positions could not be transformed into base_link");
     bitbots_msgs::KickResult result;
     result.result = bitbots_msgs::KickResult::REJECTED;
     server_.setAborted(result, "Transformation of feet into base_link not possible");
   }
+
+  visualizer_.displayReceivedGoal(goal);
+
+  /* Set engines goal and start calculating */
+  KickGoals goals;
+  goals.ball_position = goal->ball_position;
+  goals.header = goal->header;
+  goals.kick_direction = goal->kick_direction;
+  goals.kick_speed = goal->kick_speed;
+  goals.r_foot_pose = foot_poses.first;
+  goals.l_foot_pose = foot_poses.second;
+
+  try {
+    engine_.setGoals(goals);
+  }
+  catch (tf2::TransformException &e) {
+    ROS_ERROR_STREAM("Could not transform goal to needed tf frames: " << e.what());
+    bitbots_msgs::KickResult result;
+    result.result = bitbots_msgs::KickResult::REJECTED;
+    server_.setAborted(result, "Could not transform goal to needed tf frames");
+    return;
+  }
+
+  stabilizer_.reset();
+  ik_.reset();
+  visualizer_.displayWindupPoint(engine_.getWindupPoint(), (engine_.isLeftKick()) ? "r_sole" : "l_sole");
+  visualizer_.displayFlyingSplines(engine_.getSplines(), (engine_.isLeftKick()) ? "r_sole" : "l_sole");
+  loopEngine();
+
+  /* Figure out the reason why loopEngine() returned and act accordingly */
+  if (server_.isPreemptRequested()) {
+    /* Confirm that we canceled the previous goal */
+    ROS_INFO("Cancelled old goal");
+    bitbots_msgs::KickResult result;
+    result.result = bitbots_msgs::KickResult::ABORTED;
+    server_.setPreempted(result);
+  } else {
+    /* Publish results */
+    ROS_INFO("Done kicking ball");
+    bitbots_msgs::KickResult result;
+    result.result = bitbots_msgs::KickResult::SUCCESS;
+    server_.setSucceeded(result);
+  }
 }
 
-std::optional<std::pair<geometry_msgs::Pose, geometry_msgs::Pose>> KickNode::getFootPoses() {
+std::pair<geometry_msgs::Pose, geometry_msgs::Pose> KickNode::getFootPoses() {
   ros::Time time = ros::Time::now();
 
   /* Construct zero-positions for both feet in their respective local frames */
@@ -152,13 +153,9 @@ std::optional<std::pair<geometry_msgs::Pose, geometry_msgs::Pose>> KickNode::get
 
   /* Transform both feet poses into the other foot's frame */
   geometry_msgs::PoseStamped r_foot_transformed, l_foot_transformed;
-  try {
-    tf_buffer_.transform(r_foot_origin, r_foot_transformed, "l_sole",
-                         ros::Duration(0.2)); // TODO lookup thrown exceptions in internet and catch
-    tf_buffer_.transform(l_foot_origin, l_foot_transformed, "r_sole", ros::Duration(0.2));
-  } catch (tf2::TransformException &e) {
-    return std::nullopt;
-  }
+  tf_buffer_.transform(r_foot_origin, r_foot_transformed, "l_sole",
+                       ros::Duration(0.2));
+  tf_buffer_.transform(l_foot_origin, l_foot_transformed, "r_sole", ros::Duration(0.2));
 
   return std::pair(r_foot_transformed.pose, l_foot_transformed.pose);
 }


### PR DESCRIPTION
this might not fix all crashes but the most obvious ones are now caught.

closes #40 