### PR TITLE
kick: add parameters for trunk orientation

### DIFF
--- a/bitbots_dynamic_kick/cfg/bitbots_dynamic_kick_params.cfg
+++ b/bitbots_dynamic_kick/cfg/bitbots_dynamic_kick_params.cfg
@@ -27,14 +27,23 @@ group_engine_distances.add("kick_windup_distance", double_t, 2,
 group_engine_distances.add("trunk_height", double_t, 4,
                            "Height of the trunk [m]",
                            0.4, min=0, max=0.6)
+group_engine_distances.add("trunk_roll", double_t, 4,
+                           "Roll of the trunk, positive means toward the support foot [rad]",
+                           0, min=-1, max=1)
+group_engine_distances.add("trunk_pitch", double_t, 4,
+                           "Pitch of the trunk, positive means toward the front [rad]",
+                           0, min=-1, max=1)
+group_engine_distances.add("trunk_yaw", double_t, 4,
+                           "Yaw of the trunk, positive means turning toward the kicking foot [rad]",
+                           0, min=-1, max=1)
 
 group_engine_timings = group_engine.add_group("Timings")
 group_engine_timings.add("move_trunk_time", double_t, 3,
                          "How long it should take to move the trunk above the support foot before raising the flying foot [s]",
-                         0.8, min=0)
+                         1.5, min=0)
 group_engine_timings.add("raise_foot_time", double_t, 3,
                          "How long it should take to raise the flying foot from the ground [s]",
-                         0.1, min=0)
+                         0.7, min=0)
 group_engine_timings.add("move_to_ball_time", double_t, 3,
                          "How long it should take to move the raised foot to the windup point [s]",
                          1, min=0)
@@ -71,7 +80,7 @@ group_stabilizing_bioik.add("trunk_weight", double_t, 4,
 group_stabilizing_cop = group_stabilizing.add_group("CenterOfPressure regulation")
 group_stabilizing_cop.add("use_center_of_pressure", bool_t, 4,
                           "Use the center of pressure for stabilizing",
-                          True)
+                          False)
 group_stabilizing_cop.add("stabilizing_point_x", double_t, 4,
                           "Where to stabilize over in x direction. Measured from the support foots *_sole frame [m]",
                           0.0, min=-0.5, max=0.5)

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_engine.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_engine.h
@@ -23,6 +23,10 @@ struct KickParams {
   double kick_windup_distance;
   double trunk_height;
 
+  double trunk_roll;
+  double trunk_pitch;
+  double trunk_yaw;
+
   double move_trunk_time = 1;
   double raise_foot_time = 1;
   double move_to_ball_time = 1;

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_engine.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_engine.h
@@ -116,8 +116,8 @@ class KickEngine : public bitbots_splines::AbstractEngine<KickGoals, KickPositio
 
   int getPercentDone() const override;
 
-  bitbots_splines::PoseSpline getFlyingSplines() const ;
-  bitbots_splines::PoseSpline getTrunkSplines() const ;
+  bitbots_splines::PoseSpline getFlyingSplines() const;
+  bitbots_splines::PoseSpline getTrunkSplines() const;
 
   void setParams(KickParams params);
 
@@ -170,7 +170,6 @@ class KickEngine : public bitbots_splines::AbstractEngine<KickGoals, KickPositio
                              const geometry_msgs::Quaternion &kick_direction);
 
   geometry_msgs::Transform getTrunkPose();
-
 
   /**
    * Calculate the yaw of the kicking foot, so that it is turned

--- a/bitbots_dynamic_kick/package.xml
+++ b/bitbots_dynamic_kick/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_dynamic_kick</name>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
   <description>
 	  The bitbots_dynamic_kick package implements a kick which is not based on keyframe animations.
 	  Instead it aims to dynamically reach it's movement goal while keeping the robot stable and controllable.

--- a/bitbots_dynamic_kick/src/kick_engine.cpp
+++ b/bitbots_dynamic_kick/src/kick_engine.cpp
@@ -200,10 +200,16 @@ void KickEngine::calcSplines(const geometry_msgs::Pose &flying_foot_pose, const 
   tf2::Matrix3x3(trunk_rotation).getRPY(trunk_r, trunk_p, trunk_y);
 
   trunk_spline_.roll()->addPoint(0, trunk_r);
+  trunk_spline_.roll()->addPoint(phase_timings_.raise_foot, kick_foot_sign * params_.trunk_roll);
+  trunk_spline_.roll()->addPoint(phase_timings_.lower_foot, kick_foot_sign * params_.trunk_roll);
   trunk_spline_.roll()->addPoint(phase_timings_.move_trunk_back, trunk_r);
   trunk_spline_.pitch()->addPoint(0, trunk_p);
+  trunk_spline_.pitch()->addPoint(phase_timings_.raise_foot, params_.trunk_pitch);
+  trunk_spline_.pitch()->addPoint(phase_timings_.lower_foot, params_.trunk_pitch);
   trunk_spline_.pitch()->addPoint(phase_timings_.move_trunk_back, trunk_p);
   trunk_spline_.yaw()->addPoint(0, trunk_y);
+  trunk_spline_.yaw()->addPoint(phase_timings_.raise_foot, kick_foot_sign * params_.trunk_yaw);
+  trunk_spline_.yaw()->addPoint(phase_timings_.lower_foot, kick_foot_sign * params_.trunk_yaw);
   trunk_spline_.yaw()->addPoint(phase_timings_.move_trunk_back, trunk_y);
 }
 

--- a/bitbots_dynamic_kick/src/kick_engine.cpp
+++ b/bitbots_dynamic_kick/src/kick_engine.cpp
@@ -109,20 +109,20 @@ void KickEngine::calcSplines(const geometry_msgs::Pose &flying_foot_pose, const 
   flying_foot_spline_.x()->addPoint(phase_timings_.raise_foot, 0);
   flying_foot_spline_.x()->addPoint(phase_timings_.windup, windup_point_.x(), 0, 0);
   flying_foot_spline_.x()->addPoint(phase_timings_.kick, ball_position_.x(),
-                                              speed_vector.x() * kick_speed_, 0);
+                                    speed_vector.x() * kick_speed_, 0);
   flying_foot_spline_.x()->addPoint(phase_timings_.move_back, 0);
   flying_foot_spline_.x()->addPoint(phase_timings_.lower_foot, 0);
   flying_foot_spline_.x()->addPoint(phase_timings_.move_trunk_back, 0);
 
   flying_foot_spline_.y()->addPoint(0, flying_foot_pose.position.y);
-  flying_foot_spline_.y()->addPoint(phase_timings_.move_trunk, kick_foot_sign*params_.foot_distance);
-  flying_foot_spline_.y()->addPoint(phase_timings_.raise_foot, kick_foot_sign*params_.foot_distance);
+  flying_foot_spline_.y()->addPoint(phase_timings_.move_trunk, kick_foot_sign * params_.foot_distance);
+  flying_foot_spline_.y()->addPoint(phase_timings_.raise_foot, kick_foot_sign * params_.foot_distance);
   flying_foot_spline_.y()->addPoint(phase_timings_.windup, windup_point_.y(), 0, 0);
   flying_foot_spline_.y()
-      ->addPoint(phase_timings_.kick, ball_position_.y(), speed_vector.y()*kick_speed_, 0);
-  flying_foot_spline_.y()->addPoint(phase_timings_.move_back, kick_foot_sign*params_.foot_distance);
-  flying_foot_spline_.y()->addPoint(phase_timings_.lower_foot, kick_foot_sign*params_.foot_distance);
-  flying_foot_spline_.y()->addPoint(phase_timings_.move_trunk_back, kick_foot_sign*params_.foot_distance);
+      ->addPoint(phase_timings_.kick, ball_position_.y(), speed_vector.y() * kick_speed_, 0);
+  flying_foot_spline_.y()->addPoint(phase_timings_.move_back, kick_foot_sign * params_.foot_distance);
+  flying_foot_spline_.y()->addPoint(phase_timings_.lower_foot, kick_foot_sign * params_.foot_distance);
+  flying_foot_spline_.y()->addPoint(phase_timings_.move_trunk_back, kick_foot_sign * params_.foot_distance);
 
   flying_foot_spline_.z()->addPoint(0, flying_foot_pose.position.z);
   flying_foot_spline_.z()->addPoint(phase_timings_.move_trunk, 0);
@@ -130,7 +130,7 @@ void KickEngine::calcSplines(const geometry_msgs::Pose &flying_foot_pose, const 
   flying_foot_spline_.z()->addPoint(phase_timings_.windup, params_.foot_rise);
   flying_foot_spline_.z()->addPoint(phase_timings_.kick, params_.foot_rise);
   flying_foot_spline_.z()->addPoint(phase_timings_.move_back, params_.foot_rise);
-  flying_foot_spline_.z()->addPoint(phase_timings_.lower_foot, 0.4*params_.foot_rise);
+  flying_foot_spline_.z()->addPoint(phase_timings_.lower_foot, 0.4 * params_.foot_rise);
   flying_foot_spline_.z()->addPoint(phase_timings_.move_trunk_back, 0);
 
   /* Flying foot orientation */
@@ -172,21 +172,21 @@ void KickEngine::calcSplines(const geometry_msgs::Pose &flying_foot_pose, const 
   trunk_spline_.x()->addPoint(phase_timings_.lower_foot, params_.stabilizing_point_x);
   trunk_spline_.x()->addPoint(phase_timings_.move_trunk_back, 0);
 
-  trunk_spline_.y()->addPoint(0, kick_foot_sign*(params_.foot_distance/2.0));
+  trunk_spline_.y()->addPoint(0, kick_foot_sign * (params_.foot_distance / 2.0));
   trunk_spline_.y()
-      ->addPoint(phase_timings_.move_trunk, kick_foot_sign*(-params_.stabilizing_point_y));
+      ->addPoint(phase_timings_.move_trunk, kick_foot_sign * (-params_.stabilizing_point_y));
   trunk_spline_.y()
-      ->addPoint(phase_timings_.raise_foot, kick_foot_sign*(-params_.stabilizing_point_y));
+      ->addPoint(phase_timings_.raise_foot, kick_foot_sign * (-params_.stabilizing_point_y));
   trunk_spline_.y()
-      ->addPoint(phase_timings_.windup, kick_foot_sign*(-params_.stabilizing_point_y));
+      ->addPoint(phase_timings_.windup, kick_foot_sign * (-params_.stabilizing_point_y));
   trunk_spline_.y()
-      ->addPoint(phase_timings_.kick, kick_foot_sign*(-params_.stabilizing_point_y));
+      ->addPoint(phase_timings_.kick, kick_foot_sign * (-params_.stabilizing_point_y));
   trunk_spline_.y()
-      ->addPoint(phase_timings_.move_back, kick_foot_sign*(-params_.stabilizing_point_y));
+      ->addPoint(phase_timings_.move_back, kick_foot_sign * (-params_.stabilizing_point_y));
   trunk_spline_.y()
-      ->addPoint(phase_timings_.lower_foot, kick_foot_sign*(-params_.stabilizing_point_y));
+      ->addPoint(phase_timings_.lower_foot, kick_foot_sign * (-params_.stabilizing_point_y));
   trunk_spline_.y()
-      ->addPoint(phase_timings_.move_trunk_back, kick_foot_sign*(params_.foot_distance/2.0));
+      ->addPoint(phase_timings_.move_trunk_back, kick_foot_sign * (params_.foot_distance / 2.0));
 
   trunk_spline_.z()->addPoint(0, trunk_pose.translation.z);
   trunk_spline_.z()->addPoint(phase_timings_.move_trunk, params_.trunk_height);
@@ -326,11 +326,11 @@ int KickEngine::getPercentDone() const {
 }
 
 bitbots_splines::PoseSpline KickEngine::getFlyingSplines() const {
-    return flying_foot_spline_;
+  return flying_foot_spline_;
 }
 
 bitbots_splines::PoseSpline KickEngine::getTrunkSplines() const {
-    return trunk_spline_;
+  return trunk_spline_;
 }
 
 KickPhase KickEngine::getPhase() const {

--- a/bitbots_dynamic_kick/src/kick_node.cpp
+++ b/bitbots_dynamic_kick/src/kick_node.cpp
@@ -50,6 +50,9 @@ void KickNode::reconfigureCallback(bitbots_dynamic_kick::DynamicKickConfig &conf
   params.foot_distance = config.foot_distance;
   params.kick_windup_distance = config.kick_windup_distance;
   params.trunk_height = config.trunk_height;
+  params.trunk_roll = config.trunk_roll;
+  params.trunk_pitch = config.trunk_pitch;
+  params.trunk_yaw = config.trunk_yaw;
   params.move_trunk_time = config.move_trunk_time;
   params.raise_foot_time = config.raise_foot_time;
   params.move_to_ball_time = config.move_to_ball_time;

--- a/bitbots_dynamic_kick/src/stabilizer.cpp
+++ b/bitbots_dynamic_kick/src/stabilizer.cpp
@@ -38,10 +38,10 @@ std::unique_ptr<bio_ik::BioIKKinematicsQueryOptions> Stabilizer::stabilize(const
     cop_y_error = cop_y - positions.trunk_pose.position.y;
     cop_x_error_sum_ += cop_x_error;
     cop_y_error_sum_ += cop_y_error;
-    double x = positions.trunk_pose.position.x - cop_x*p_x_factor_ - i_x_factor_*cop_x_error_sum_
-                                - d_x_factor_*(cop_x_error - cop_x_error_);
-    double y = positions.trunk_pose.position.y - cop_y*p_y_factor_ - i_y_factor_*cop_y_error_sum_
-                                - d_y_factor_*(cop_y_error - cop_y_error_);
+    double x = positions.trunk_pose.position.x - cop_x * p_x_factor_ - i_x_factor_ * cop_x_error_sum_
+        - d_x_factor_ * (cop_x_error - cop_x_error_);
+    double y = positions.trunk_pose.position.y - cop_y * p_y_factor_ - i_y_factor_ * cop_y_error_sum_
+        - d_y_factor_ * (cop_y_error - cop_y_error_);
     cop_x_error_ = cop_x_error;
     cop_y_error_ = cop_y_error;
     /* Do not use control for height and rotation */


### PR DESCRIPTION
## Proposed changes
This pull request adds parameters for the trunk orientation (roll, pitch, yaw)

## Necessary checks
- [x] Update package version
- [x] Run linters
- [x] Run `catkin build`
- [x] Write documentation
- [x] Test on your machine
- [x] Test on the robot