### PR TITLE
walking: add missing override in ik header file

### DIFF
--- a/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_ik.h
+++ b/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_ik.h
@@ -10,7 +10,7 @@ class WalkIK : public bitbots_splines::AbstractIK {
 
   bitbots_splines::JointGoals calculate(std::unique_ptr<bio_ik::BioIKKinematicsQueryOptions> ik_goals) override;
   void init(moveit::core::RobotModelPtr kinematic_model) override;
-  void reset();
+  void reset() override;
   void setBioIKTimeout(double timeout);
 
  private:

--- a/bitbots_quintic_walk/package.xml
+++ b/bitbots_quintic_walk/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_quintic_walk</name>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <description>This is a simple open-loop walking engine which uses quintic splines to define the trajectories of both feet in cartesian space. An inverse kinematic is used to translate these into joint space. The parameters of the walking can be adjusted using dynamic_reconfigure.</description>
 
   <maintainer email="7engelke@informatik.uni-hamburg.de">Timon Engelke</maintainer>


### PR DESCRIPTION
## Proposed changes
This adds a missing `override` in the `walk_ik.h` file that lead to compiler warnings.

## Necessary checks
- [x] Update package version
- [x] Run linters
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Test on your machine
- [ ] Test on the robot

