### PR TITLE
Kick: enable debug when someone subscribes to the publisher

### DIFF
--- a/bitbots_dynamic_kick/cfg/bitbots_dynamic_kick_params.cfg
+++ b/bitbots_dynamic_kick/cfg/bitbots_dynamic_kick_params.cfg
@@ -114,9 +114,6 @@ group_stabilizing_cop.add("stabilizing_d_y", double_t, 4,
                           1.5, min=-20, max=20)
 
 group_visualization = gen.add_group("Visualization", type="tab")
-group_visualization.add("force_enable", bool_t, 9,
-                        "force publishing of visualization topics event though the rosparam /debug_active is not true",
-                        False)
 group_visualization.add("spline_smoothness", int_t, 8,
                         "how many points to extract from splines for visualization",
                         100, min=1, max=200)

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/visualizer.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/visualizer.h
@@ -24,7 +24,6 @@ enum MarkerIDs {
 };
 
 struct VisualizationParams {
-  bool force_enable;
   int spline_smoothness;
 };
 
@@ -52,9 +51,6 @@ class Visualizer : bitbots_splines::AbstractVisualizer {
   std::string base_topic_;
   const std::string marker_ns_ = "bitbots_dynamic_kick";
   VisualizationParams params_;
-  bool param_debug_active_;
-
-  bool isEnabled();
 };
 }
 

--- a/bitbots_dynamic_kick/package.xml
+++ b/bitbots_dynamic_kick/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_dynamic_kick</name>
-  <version>0.1.1</version>
+  <version>0.1.2</version>
   <description>
 	  The bitbots_dynamic_kick package implements a kick which is not based on keyframe animations.
 	  Instead it aims to dynamically reach it's movement goal while keeping the robot stable and controllable.

--- a/bitbots_dynamic_kick/src/kick_node.cpp
+++ b/bitbots_dynamic_kick/src/kick_node.cpp
@@ -73,7 +73,6 @@ void KickNode::reconfigureCallback(bitbots_dynamic_kick::DynamicKickConfig &conf
   stabilizer_.setDFactor(config.stabilizing_d_x, config.stabilizing_d_y);
 
   VisualizationParams viz_params = VisualizationParams();
-  viz_params.force_enable = config.force_enable;
   viz_params.spline_smoothness = config.spline_smoothness;
   visualizer_.setParams(viz_params);
 }

--- a/bitbots_dynamic_kick/src/visualizer.cpp
+++ b/bitbots_dynamic_kick/src/visualizer.cpp
@@ -20,8 +20,6 @@ Visualizer::Visualizer(const std::string &base_topic) :
       /* queue_size */ 5, /* latch */ true);
   windup_publisher_ = node_handle_.advertise<visualization_msgs::Marker>(base_topic_ + "kick_windup_point",
       /* queue_size */ 5, /* latch */ true);
-
-  node_handle_.getParam("/debug_active", param_debug_active_);
 }
 
 void Visualizer::setParams(VisualizationParams params) {
@@ -30,7 +28,7 @@ void Visualizer::setParams(VisualizationParams params) {
 
 void Visualizer::displayFlyingSplines(bitbots_splines::PoseSpline splines,
                                       const std::string &support_foot_frame) {
-  if (!isEnabled())
+  if (foot_spline_publisher_.getNumSubscribers() == 0)
     return;
 
   visualization_msgs::Marker path = getPath(splines, support_foot_frame, params_.spline_smoothness);
@@ -40,7 +38,7 @@ void Visualizer::displayFlyingSplines(bitbots_splines::PoseSpline splines,
 }
 
 void Visualizer::displayTrunkSplines(bitbots_splines::PoseSpline splines) {
-  if (!isEnabled())
+  if (trunk_spline_publisher_.getNumSubscribers() == 0)
     return;
 
   visualization_msgs::Marker path = getPath(splines, "base_link", params_.spline_smoothness);
@@ -50,7 +48,7 @@ void Visualizer::displayTrunkSplines(bitbots_splines::PoseSpline splines) {
 }
 
 void Visualizer::displayReceivedGoal(const bitbots_msgs::KickGoalConstPtr &goal) {
-  if (!isEnabled())
+  if (goal_publisher_.getNumSubscribers() == 0)
     return;
 
   visualization_msgs::Marker
@@ -68,7 +66,7 @@ void Visualizer::displayReceivedGoal(const bitbots_msgs::KickGoalConstPtr &goal)
 }
 
 void Visualizer::displayWindupPoint(const tf2::Vector3 &kick_windup_point, const std::string &support_foot_frame) {
-  if (!isEnabled())
+  if (windup_publisher_.getNumSubscribers() == 0)
     return;
 
   visualization_msgs::Marker marker = getMarker(kick_windup_point, support_foot_frame);
@@ -78,10 +76,6 @@ void Visualizer::displayWindupPoint(const tf2::Vector3 &kick_windup_point, const
   marker.color.g = 1;
 
   windup_publisher_.publish(marker);
-}
-
-bool Visualizer::isEnabled() {
-  return params_.force_enable || param_debug_active_;
 }
 
 }


### PR DESCRIPTION
## Proposed changes
This pull request enables the debug calculations only when someone subscribes to the corresponding publishers. Therefore, the `force_enable` and `debug_active` parameters are removed.

## Necessary checks
- [x] Update package version
- [ ] Run linters
- [x] Run `catkin build`
- [ ] Write documentation
- [x] Test on your machine
- [ ] Test on the robot

