### PR TITLE
odometry: fix to use only walk odometry if IMU is missing

### DIFF
--- a/bitbots_odometry/package.xml
+++ b/bitbots_odometry/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_odometry</name>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <description>The bitbots_odometry package</description>
 
   <maintainer email="5guelden@informatik.uni-hamburg.de">Jasper Güldenstein</maintainer>

--- a/bitbots_odometry/src/odometry_fuser.cpp
+++ b/bitbots_odometry/src/odometry_fuser.cpp
@@ -88,9 +88,13 @@ OdometryFuser::OdometryFuser() {
       tf2::Matrix3x3 odom_rotation_matrix(odom_orientation);
       odom_rotation_matrix.getRPY(placeholder, placeholder, walking_yaw);
 
-      // combine orientations to new quaternion
+      // combine orientations to new quaternion if IMU is active, use purely odom otherwise
       tf2::Quaternion new_orientation;
-      new_orientation.setRPY(imu_roll, imu_pitch, walking_yaw);
+      if(imu_active){
+        new_orientation.setRPY(imu_roll, imu_pitch, walking_yaw);
+       }else{
+        new_orientation = odom_orientation;
+       }
 
       // combine it all into a tf
       tf.header.stamp = ros::Time::now();


### PR DESCRIPTION
In case of missing IMU we only want to use the walk odometry

## Necessary checks
- [x] Update package version
- [x] Run linters
- [x] Run `catkin build`
- [x] Write documentation
- [x] Test on your machine
- [ ] Test on the robot

