### PR TITLE
odometry: restructure to include kick support state

### DIFF
--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_node.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_node.h
@@ -61,6 +61,7 @@ class KickNode {
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener listener_;
   robot_model_loader::RobotModelLoader robot_model_loader_;
+  char previous_support_foot_;
 
   /**
    * Do main loop in which KickEngine::update() gets called repeatedly.

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_node.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_node.h
@@ -61,7 +61,7 @@ class KickNode {
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener listener_;
   robot_model_loader::RobotModelLoader robot_model_loader_;
-  char previous_support_foot_;
+  bool was_support_foot_published_;
 
   /**
    * Do main loop in which KickEngine::update() gets called repeatedly.

--- a/bitbots_dynamic_kick/src/kick_node.cpp
+++ b/bitbots_dynamic_kick/src/kick_node.cpp
@@ -22,7 +22,7 @@ KickNode::KickNode() :
   ik_.init(kinematic_model);
 
   joint_goal_publisher_ = node_handle_.advertise<bitbots_msgs::JointCommand>("kick_motor_goals", 1);
-  support_foot_publisher_ = node_handle_.advertise<std_msgs::Char>("dynamic_kick_support_state", 1, true);
+  support_foot_publisher_ = node_handle_.advertise<std_msgs::Char>("dynamic_kick_support_state", 1, /* latch = */ true);
   cop_l_subscriber_ = node_handle_.subscribe("cop_l", 1, &KickNode::copLCallback, this);
   cop_r_subscriber_ = node_handle_.subscribe("cop_r", 1, &KickNode::copRCallback, this);
   server_.start();

--- a/bitbots_dynamic_kick/src/kick_node.cpp
+++ b/bitbots_dynamic_kick/src/kick_node.cpp
@@ -22,7 +22,7 @@ KickNode::KickNode() :
   ik_.init(kinematic_model);
 
   joint_goal_publisher_ = node_handle_.advertise<bitbots_msgs::JointCommand>("kick_motor_goals", 1);
-  support_foot_publisher_ = node_handle_.advertise<std_msgs::Char>("dynamic_kick_support_state", 1);
+  support_foot_publisher_ = node_handle_.advertise<std_msgs::Char>("dynamic_kick_support_state", 1, true);
   cop_l_subscriber_ = node_handle_.subscribe("cop_l", 1, &KickNode::copLCallback, this);
   cop_r_subscriber_ = node_handle_.subscribe("cop_r", 1, &KickNode::copRCallback, this);
   server_.start();
@@ -215,7 +215,11 @@ void KickNode::publishGoals(const bitbots_splines::JointGoals &goals) {
 void KickNode::publishSupportFoot(bool is_left_kick) {
   std_msgs::Char msg;
   msg.data = !is_left_kick ? 'l' : 'r';
-  support_foot_publisher_.publish(msg);
+  // only publish if there was a change
+  if(previous_support_foot_ != msg.data){
+    support_foot_publisher_.publish(msg);
+    previous_support_foot_ = msg.data;
+  }
 }
 
 }

--- a/bitbots_dynamic_kick/src/kick_node.cpp
+++ b/bitbots_dynamic_kick/src/kick_node.cpp
@@ -81,6 +81,7 @@ void KickNode::executeCb(const bitbots_msgs::KickGoalConstPtr &goal) {
   // TODO: maybe switch to goal callback to be able to reject goals properly
   ROS_INFO("Accepted new goal");
   engine_.reset();
+  was_support_foot_published_ = false;
 
   std::pair<geometry_msgs::Pose, geometry_msgs::Pose> foot_poses;
   try {
@@ -215,10 +216,10 @@ void KickNode::publishGoals(const bitbots_splines::JointGoals &goals) {
 void KickNode::publishSupportFoot(bool is_left_kick) {
   std_msgs::Char msg;
   msg.data = !is_left_kick ? 'l' : 'r';
-  // only publish if there was a change
-  if(previous_support_foot_ != msg.data){
+  // only publish one time per kick
+  if(!was_support_foot_published_){
     support_foot_publisher_.publish(msg);
-    previous_support_foot_ = msg.data;
+    was_support_foot_published_ = true;
   }
 }
 

--- a/bitbots_odometry/CMakeLists.txt
+++ b/bitbots_odometry/CMakeLists.txt
@@ -139,7 +139,7 @@ include_directories(
 ## With catkin_make all packages are built within a single CMake context
 ## The recommended prefix ensures that target names across packages don't collide
 add_executable(odometry_fuser src/odometry_fuser.cpp)
-add_executable(walk_odometry src/walk_odometry.cpp)
+add_executable(motion_odometry src/motion_odometry.cpp)
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the
@@ -156,7 +156,7 @@ target_link_libraries(odometry_fuser
   ${catkin_LIBRARIES}
 )
 
-target_link_libraries(walk_odometry
+target_link_libraries(motion_odometry
   ${catkin_LIBRARIES}
 )
 

--- a/bitbots_odometry/launch/odometry.launch
+++ b/bitbots_odometry/launch/odometry.launch
@@ -1,3 +1,4 @@
 <launch>
+    <node name="motion_odometry" pkg="bitbots_odometry" type="motion_odometry" />
     <node name="odometry_fuser" pkg="bitbots_odometry" type="odometry_fuser" />
 </launch>

--- a/bitbots_odometry/package.xml
+++ b/bitbots_odometry/package.xml
@@ -1,50 +1,17 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_odometry</name>
-  <version>1.0.1</version>
+  <version>1.0.3</version>
   <description>The bitbots_odometry package</description>
 
   <maintainer email="5guelden@informatik.uni-hamburg.de">Jasper Güldenstein</maintainer>
 
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>MIT</license>
 
-
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/bitbots_odometry</url> -->
-
-
-  <!-- Author tags are optional, multiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintainers, but could be -->
-  <!-- Example: -->
+  <author email="bestmann@informatik.uni-hamburg.de">Marc Bestmann</author>
   <author email="7vahl@informatik.uni-hamburg.de">Florian Vahl</author>
   <author email="jasper@bit-bots.de">Jasper Güldenstein</author>
 
-  <!-- The *depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
-  <!--   <depend>roscpp</depend> -->
-  <!--   Note that this is equivalent to the following: -->
-  <!--   <build_depend>roscpp</build_depend> -->
-  <!--   <exec_depend>roscpp</exec_depend> -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use build_export_depend for packages you need in order to build against this package: -->
-  <!--   <build_export_depend>message_generation</build_export_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use exec_depend for packages you need at runtime: -->
-  <!--   <exec_depend>message_runtime</exec_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
-  <!-- Use doc_depend for packages you need only for building documentation: -->
-  <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
@@ -57,13 +24,10 @@
   <exec_depend>tf2</exec_depend>
   <depend>bitbots_docs</depend>
 
-  <!-- The export tag contains other, unspecified, tags -->
   <export>
-    <!-- Other tools can request additional information be placed here -->
     <bitbots_documentation>
       <status>tested_robot</status>
       <language>c++</language>
     </bitbots_documentation>
-
   </export>
 </package>

--- a/bitbots_odometry/src/motion_odometry.cpp
+++ b/bitbots_odometry/src/motion_odometry.cpp
@@ -8,9 +8,9 @@
 #include <nav_msgs/Odometry.h>
 
 
-class WalkOdometry {
+class MotionOdometry {
  public:
-  WalkOdometry();
+  MotionOdometry();
  private:
   ros::Time joint_update_time_;
   char current_support_state_;
@@ -23,8 +23,7 @@ class WalkOdometry {
   void odomCallback(nav_msgs::Odometry msg);
 };
 
-WalkOdometry::WalkOdometry() {
-  // todo think about if this node should be integrated into the walk node
+MotionOdometry::MotionOdometry() {
   ros::NodeHandle n("~");
   bool publish_walk_odom_tf;
   n.param<bool>("/publish_walk_odom_tf", publish_walk_odom_tf, false);
@@ -32,11 +31,13 @@ WalkOdometry::WalkOdometry() {
   previous_support_state_ = 'n';
   std::string current_support_link = "r_sole";
   std::string next_support_link;
-  ros::Subscriber support_state_sub =
-      n.subscribe("/walk_support_state", 1, &WalkOdometry::supportCallback, this, ros::TransportHints().tcpNoDelay());
+  ros::Subscriber walk_support_state_sub =
+      n.subscribe("/walk_support_state", 1, &MotionOdometry::supportCallback, this, ros::TransportHints().tcpNoDelay());
+  ros::Subscriber kick_support_state_sub =
+      n.subscribe("/dynamic_kick_support_state", 1, &MotionOdometry::supportCallback, this, ros::TransportHints().tcpNoDelay());
   ros::Subscriber joint_state_sub =
-      n.subscribe("/joint_states", 1, &WalkOdometry::jointStateCb, this, ros::TransportHints().tcpNoDelay());
-  ros::Subscriber odom_subscriber = n.subscribe("/walk_engine_odometry", 1, &WalkOdometry::odomCallback, this);
+      n.subscribe("/joint_states", 1, &MotionOdometry::jointStateCb, this, ros::TransportHints().tcpNoDelay());
+  ros::Subscriber odom_subscriber = n.subscribe("/walk_engine_odometry", 1, &MotionOdometry::odomCallback, this);
 
   ros::Publisher pub_odometry = n.advertise<nav_msgs::Odometry>("/walk_odometry", 1);
   tf2::Transform odometry_to_support_foot = tf2::Transform();
@@ -139,7 +140,7 @@ WalkOdometry::WalkOdometry() {
   }
 }
 
-void WalkOdometry::supportCallback(const std_msgs::Char msg) {
+void MotionOdometry::supportCallback(const std_msgs::Char msg) {
   current_support_state_ = msg.data;
 
   // remember if we recieved first support state, only remember left or right
@@ -148,12 +149,12 @@ void WalkOdometry::supportCallback(const std_msgs::Char msg) {
   }
 }
 
-void WalkOdometry::jointStateCb(const sensor_msgs::JointState &msg) {
+void MotionOdometry::jointStateCb(const sensor_msgs::JointState &msg) {
   current_joint_states_ = msg;
   joint_update_time_ = ros::Time::now();
 }
 
-void WalkOdometry::odomCallback(nav_msgs::Odometry msg){
+void MotionOdometry::odomCallback(nav_msgs::Odometry msg){
   current_odom_msg_ = msg;
 }
 
@@ -161,5 +162,5 @@ void WalkOdometry::odomCallback(nav_msgs::Odometry msg){
 int main(int argc, char **argv) {
   ros::init(argc, argv, "bitbots_walk_odometry");
 
-  WalkOdometry o;
+  MotionOdometry o;
 }


### PR DESCRIPTION
It is necessary to also include the kick support state into the odometry. This was previously missing.


## Necessary checks
- [x] Update package version
- [x] Run linters
- [x] Run `catkin build`
- [x] Write documentation
- [x] Test on your machine
- [ ] Test on the robot

