### PR TITLE
walk: add save of foot state for phase reset

### DIFF
--- a/bitbots_quintic_walk/cfg/bitbots_quintic_walk_params.cfg
+++ b/bitbots_quintic_walk/cfg/bitbots_quintic_walk_params.cfg
@@ -31,7 +31,7 @@ group_reset.add("ground_min_pressure", double_t, 1,
                 "Minimal pressure on flying foot to say that it has contact to the ground. Used to invoke phase reset.",
                 min=0, max=10)
 group_reset.add("phase_reset_phase", double_t, 1,
-                "Minimal phase distance to end of step to invoke phase reset", min=0, max=10)
+                "Minimal phase distance to end of step to invoke phase reset", min=0, max=1)
 
 group_stability.add("pause_duration", double_t, 1,
                     "Time that the walking is paused when becoming unstable [s]", min=0, max=10)

--- a/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_engine.h
+++ b/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_engine.h
@@ -159,7 +159,7 @@ class WalkEngine : public bitbots_splines::AbstractEngine<WalkRequest, WalkRespo
 
   void buildWalkDisableTrajectories(bool foot_in_idle_position);
 
-  void saveCurrentTrunkState();
+  void saveCurrentRobotState();
 
   /**
    * Compute current cartesian target from trajectories and assign it to given model through inverse kinematics.

--- a/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_engine.h
+++ b/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_engine.h
@@ -110,6 +110,9 @@ class WalkEngine : public bitbots_splines::AbstractEngine<WalkRequest, WalkRespo
   bool left_kick_requested_;
   bool right_kick_requested_;
 
+  bool phase_reset_;
+  double phase_reset_phase_;
+
   // Current support foot (left or right).
   bool is_left_support_foot_{};
 
@@ -122,13 +125,21 @@ class WalkEngine : public bitbots_splines::AbstractEngine<WalkRequest, WalkRespo
   tf2::Transform left_in_world_;
   tf2::Transform right_in_world_;
 
-  //Trunk pose and orientation position, velocity and acceleration at half cycle start.
+  //Trunk pose and orientation position, velocity and acceleration at last half step start.
   tf2::Vector3 trunk_pos_at_foot_change_;
   tf2::Vector3 trunk_pos_vel_at_foot_change_;
   tf2::Vector3 trunk_pos_acc_at_foot_change_;
   tf2::Vector3 trunk_orientation_pos_at_last_foot_change_;
   tf2::Vector3 trunk_orientation_vel_at_last_foot_change_;
   tf2::Vector3 trunk_orientation_acc_at_foot_change_;
+
+  //Foot pose and orientation position, velocity and acceleration at last half step start.
+  tf2::Vector3 foot_pos_at_foot_change_;
+  tf2::Vector3 foot_pos_vel_at_foot_change_;
+  tf2::Vector3 foot_pos_acc_at_foot_change_;
+  tf2::Vector3 foot_orientation_pos_at_last_foot_change_;
+  tf2::Vector3 foot_orientation_vel_at_last_foot_change_;
+  tf2::Vector3 foot_orientation_acc_at_foot_change_;
 
   void updatePhase(double dt);
 

--- a/bitbots_quintic_walk/package.xml
+++ b/bitbots_quintic_walk/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_quintic_walk</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <description>This is a simple open-loop walking engine which uses quintic splines to define the trajectories of both feet in cartesian space. An inverse kinematic is used to translate these into joint space. The parameters of the walking can be adjusted using dynamic_reconfigure.</description>
 
   <maintainer email="7engelke@informatik.uni-hamburg.de">Timon Engelke</maintainer>

--- a/bitbots_quintic_walk/src/walk_engine.cpp
+++ b/bitbots_quintic_walk/src/walk_engine.cpp
@@ -28,8 +28,8 @@ WalkEngine::WalkEngine() :
   dyn_reconf_server_->setCallback(f);
 
   // move left and right in world by foot distance for correct initilization
-  left_in_world_.setOrigin(tf2::Vector3{0, params_.foot_distance /2, 0});
-  right_in_world_.setOrigin(tf2::Vector3{0, -1 * params_.foot_distance /2, 0});
+  left_in_world_.setOrigin(tf2::Vector3{0, params_.foot_distance / 2, 0});
+  right_in_world_.setOrigin(tf2::Vector3{0, -1 * params_.foot_distance / 2, 0});
 }
 
 void WalkEngine::setGoals(const WalkRequest &goals) {
@@ -195,7 +195,8 @@ void WalkEngine::updatePhase(double dt) {
 }
 
 void WalkEngine::endStep() {
-  // ends the step earlier, e.g. when foot has already contact to ground
+  // ends the step earlier, e.g. when foot has already contact to gro
+  // last_phase will still held the information about the time point where the reset occurred
   if (phase_ < 0.5) {
     phase_ = 0.5;
   } else {
@@ -252,6 +253,12 @@ void WalkEngine::saveCurrentTrunkState() {
   }
   double period_time = half_period * factor;
 
+  // get the current transform to the next foot instead of the planned one (in case of phase reset)
+  tf2::Transform current_support_to_next_ = foot_spline_.getTfTransform(period_time);
+  // we use a transformation with a 0 origin, since we only want to do rotation
+  tf2::Transform rotation_to_next(current_support_to_next_);
+  rotation_to_next.setOrigin({0, 0, 0});
+
   // get last values of trunk pose and its velocities and accelerations
   tf2::Transform trunk_pose = trunk_spline_.getTfTransform(period_time);
   tf2::Vector3 trunk_pos_vel = trunk_spline_.getPositionVel(period_time);
@@ -260,20 +267,37 @@ void WalkEngine::saveCurrentTrunkState() {
   tf2::Vector3 trunk_axis_acc = trunk_spline_.getEulerAcc(period_time);
 
   // Convert the pose in next support foot frame and save
-  tf2::Transform trunk_pose_at_last = support_to_next_.inverse() * trunk_pose;
+  tf2::Transform trunk_pose_at_last = current_support_to_next_.inverse() * trunk_pose;
   trunk_pos_at_foot_change_ = trunk_pose_at_last.getOrigin();
   double roll, pitch, yaw;
   tf2::Matrix3x3(trunk_pose_at_last.getRotation()).getRPY(roll, pitch, yaw);
   trunk_orientation_pos_at_last_foot_change_ = tf2::Vector3(roll, pitch, yaw);
 
   // convert the velocities and accelerations in next support foot frame and save
-  // we use a transformation with a 0 origin, since we only want to do rotation
-  tf2::Transform rotation_to_next(support_to_next_);
-  rotation_to_next.setOrigin({0,0,0});
-  trunk_pos_vel_at_foot_change_  = rotation_to_next * trunk_pos_vel;
-  trunk_pos_acc_at_foot_change_  = rotation_to_next * trunk_pos_acc;
+  trunk_pos_vel_at_foot_change_ = rotation_to_next * trunk_pos_vel;
+  trunk_pos_acc_at_foot_change_ = rotation_to_next * trunk_pos_acc;
   trunk_orientation_vel_at_last_foot_change_ = rotation_to_next * trunk_axis_vel;
   trunk_orientation_acc_at_foot_change_ = rotation_to_next * trunk_axis_acc;
+
+  // get last values of foot pose and velocities and accelerations
+  tf2::Transform foot_pose = foot_spline_.getTfTransform(period_time);
+  tf2::Vector3 foot_pos_vel = foot_spline_.getPositionVel(period_time);
+  tf2::Vector3 foot_pos_acc = foot_spline_.getPositionAcc(period_time);
+  tf2::Vector3 foot_axis_vel = foot_spline_.getEulerVel(period_time);
+  tf2::Vector3 foot_axis_acc = foot_spline_.getEulerAcc(period_time);
+
+  // Convert the pose in next support foot frame and save
+  tf2::Transform foot_pose_at_last = current_support_to_next_.inverse() * foot_pose;
+  foot_pos_at_foot_change_ = foot_pose_at_last.getOrigin();
+  tf2::Matrix3x3(foot_pose_at_last.getRotation()).getRPY(roll, pitch, yaw);
+  foot_orientation_pos_at_last_foot_change_ = tf2::Vector3(roll, pitch, yaw);
+
+  // convert the velocities and accelerations in next support foot frame and save
+  foot_pos_vel_at_foot_change_ = rotation_to_next * foot_pos_vel;
+  foot_pos_acc_at_foot_change_ = rotation_to_next * foot_pos_acc;
+  foot_orientation_vel_at_last_foot_change_ = rotation_to_next * foot_axis_vel;
+  foot_orientation_acc_at_foot_change_ = rotation_to_next * foot_axis_acc;
+
 }
 
 void WalkEngine::buildNormalTrajectories() {
@@ -351,8 +375,10 @@ void WalkEngine::buildTrajectories(bool start_movement, bool start_step, bool ki
   is_left_support_foot_spline_.addPoint(half_period, is_left_support_foot_);
 
   //Flying foot position
-  foot_spline_.x()->addPoint(0.0, support_to_last_.getOrigin().x());
-  foot_spline_.x()->addPoint(double_support_length, support_to_last_.getOrigin().x());
+  foot_spline_.x()->addPoint(0.0, foot_pos_at_foot_change_.x(),
+                             foot_pos_vel_at_foot_change_.x(),
+                             foot_pos_acc_at_foot_change_.x());
+  foot_spline_.x()->addPoint(double_support_length, foot_pos_at_foot_change_.x());
   if (kick_step) {
     foot_spline_.x()->addPoint(double_support_length + single_support_length * params_.kick_phase,
                                support_to_next_.getOrigin().x() + params_.kick_length,
@@ -366,8 +392,10 @@ void WalkEngine::buildTrajectories(bool start_movement, bool start_step, bool ki
                              support_to_next_.getOrigin().x());
   foot_spline_.x()->addPoint(half_period, support_to_next_.getOrigin().x());
 
-  foot_spline_.y()->addPoint(0.0, support_to_last_.getOrigin().y());
-  foot_spline_.y()->addPoint(double_support_length, support_to_last_.getOrigin().y());
+  foot_spline_.y()->addPoint(0.0, foot_pos_at_foot_change_.y(),
+                             foot_pos_vel_at_foot_change_.y(),
+                             foot_pos_acc_at_foot_change_.y());
+  foot_spline_.y()->addPoint(double_support_length, foot_pos_at_foot_change_.y());
   foot_spline_.y()->addPoint(
       double_support_length + single_support_length * params_.foot_put_down_phase * params_.foot_overshoot_phase,
       support_to_next_.getOrigin().y()
@@ -376,8 +404,10 @@ void WalkEngine::buildTrajectories(bool start_movement, bool start_step, bool ki
                              support_to_next_.getOrigin().y());
   foot_spline_.y()->addPoint(half_period, support_to_next_.getOrigin().y());
 
-  foot_spline_.z()->addPoint(0.0, 0.0);
-  foot_spline_.z()->addPoint(double_support_length, 0.0);
+  foot_spline_.z()->addPoint(0.0, foot_pos_at_foot_change_.z(),
+                             foot_pos_vel_at_foot_change_.z(),
+                             foot_pos_acc_at_foot_change_.z());
+  foot_spline_.z()->addPoint(double_support_length, 0);
   foot_spline_.z()->addPoint(double_support_length + single_support_length * params_.foot_apex_phase
                                  - 0.5 * params_.foot_z_pause * single_support_length,
                              params_.foot_rise);
@@ -389,16 +419,22 @@ void WalkEngine::buildTrajectories(bool start_movement, bool start_step, bool ki
   foot_spline_.z()->addPoint(half_period, 0.0);
 
   //Flying foot orientation
-  foot_spline_.roll()->addPoint(0.0, 0.0);
+  foot_spline_.roll()->addPoint(0.0, foot_orientation_pos_at_last_foot_change_.x(),
+                                foot_orientation_vel_at_last_foot_change_.x(),
+                                foot_orientation_acc_at_foot_change_.x());
   foot_spline_.roll()->addPoint(double_support_length + 0.1 * single_support_length, 0.0);
   foot_spline_.roll()->addPoint(double_support_length + single_support_length * params_.foot_put_down_phase,
                                 params_.foot_put_down_roll_offset * support_sign);
   foot_spline_.roll()->addPoint(half_period, 0.0);
 
-  foot_spline_.pitch()->addPoint(0.0, 0.0);
+  foot_spline_.pitch()->addPoint(0.0, foot_orientation_pos_at_last_foot_change_.y(),
+                                 foot_orientation_vel_at_last_foot_change_.y(),
+                                 foot_orientation_acc_at_foot_change_.y());
   foot_spline_.pitch()->addPoint(half_period, 0.0);
 
-  foot_spline_.yaw()->addPoint(0.0, getLastEuler().z());
+  foot_spline_.yaw()->addPoint(0.0, foot_orientation_pos_at_last_foot_change_.z(),
+                               foot_orientation_vel_at_last_foot_change_.z(),
+                               foot_orientation_acc_at_foot_change_.z());
   foot_spline_.yaw()->addPoint(double_support_length, getLastEuler().z());
   foot_spline_.yaw()->addPoint(double_support_length + single_support_length * params_.foot_put_down_phase,
                                getNextEuler().z());
@@ -578,7 +614,7 @@ void WalkEngine::buildWalkDisableTrajectories(bool foot_in_idle_position) {
   is_double_support_spline_.addPoint(0.0, 1.0);
   if (foot_in_idle_position) {
     is_double_support_spline_.addPoint(half_period, 1.0);
-  }else {
+  } else {
     is_double_support_spline_.addPoint(double_support_length, 1.0);
     is_double_support_spline_.addPoint(double_support_length, 0.0);
     is_double_support_spline_.addPoint(half_period, 0.0);


### PR DESCRIPTION
Add saving of foot state in case of phase reset

## Proposed changes


## Related issues
https://github.com/bit-bots/bitbots_motion/issues/68

## Necessary checks
- [x] Update package version
- [x] Run linters
- [x] Run `catkin build`
- [x] ~~Write documentation~~
- [x] Test on your machine
- [ ] Test on the robot

