### PR TITLE
Odometry: restructure to include header files

### DIFF
--- a/bitbots_odometry/CMakeLists.txt
+++ b/bitbots_odometry/CMakeLists.txt
@@ -121,7 +121,7 @@ catkin_package(
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
 include_directories(
-# include
+  include
   ${catkin_INCLUDE_DIRS}
 )
 

--- a/bitbots_odometry/package.xml
+++ b/bitbots_odometry/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_odometry</name>
-  <version>1.0.4</version>
+  <version>1.0.5</version>
   <description>The bitbots_odometry package</description>
 
   <maintainer email="5guelden@informatik.uni-hamburg.de">Jasper Güldenstein</maintainer>

--- a/bitbots_odometry/src/motion_odometry.cpp
+++ b/bitbots_odometry/src/motion_odometry.cpp
@@ -1,27 +1,4 @@
-#include <ros/ros.h>
-#include <sensor_msgs/JointState.h>
-#include <std_msgs/Char.h>
-#include <tf2_ros/transform_broadcaster.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#include <tf2_ros/transform_listener.h>
-#include <tf2/utils.h>
-#include <nav_msgs/Odometry.h>
-
-
-class MotionOdometry {
- public:
-  MotionOdometry();
- private:
-  ros::Time joint_update_time_;
-  char current_support_state_;
-  char previous_support_state_;
-  sensor_msgs::JointState current_joint_states_;
-  nav_msgs::Odometry current_odom_msg_;
-
-  void supportCallback(std_msgs::Char msg);
-  void jointStateCb(const sensor_msgs::JointState &msg);
-  void odomCallback(nav_msgs::Odometry msg);
-};
+#include <bitbots_odometry/motion_odometry.h>
 
 MotionOdometry::MotionOdometry() {
   ros::NodeHandle n("~");

--- a/bitbots_odometry/src/odometry_fuser.cpp
+++ b/bitbots_odometry/src/odometry_fuser.cpp
@@ -1,36 +1,10 @@
+#include <bitbots_odometry/odometry_fuser.h>
+
 /*
 odom -> baselink
 walking (X, Y, Z, rZ)
 imu (rX, rY)
 */
-
-#include <ros/ros.h>
-#include <ros/console.h>
-#include <sensor_msgs/Imu.h>
-#include <tf2_ros/transform_broadcaster.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#include <geometry_msgs/TransformStamped.h>
-#include <nav_msgs/Odometry.h>
-#include <std_msgs/Char.h>
-#include <std_msgs/Time.h>
-#include <tf2/utils.h>
-
-
-// TODO Doku
-
-class OdometryFuser {
- public:
-  OdometryFuser();
- private:
-  sensor_msgs::Imu _imu_data;
-  nav_msgs::Odometry _odom_data;
-  ros::Time _imu_update_time;
-  ros::Time _odom_update_time;
-  geometry_msgs::TransformStamped tf;
-
-  void imuCallback(const sensor_msgs::Imu msg);
-  void odomCallback(const nav_msgs::Odometry msg);
-};
 
 OdometryFuser::OdometryFuser() {
   ros::NodeHandle n("~");


### PR DESCRIPTION
## Proposed changes
This splits the header files from the source files to make the documentation work. Tested in rViz.

## Necessary checks
- [x] Update package version
- [x] Run linters
- [x] Run `catkin build`
- [ ] ~~Write documentation~~
- [x] Test on your machine
- [ ] Test on the robot