### PR TITLE
add all packages to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,11 @@
 @Library('bitbots_jenkins_library') import de.bitbots.jenkins.PackageDefinition
 
 bitbotsPipeline([
-    new PackageDefinition("bitbots_animation_server", true)
+    new PackageDefinition("bitbots_animation_server", true),
+    new PackageDefinition("bitbots_dynamic_kick", true),
+    new PackageDefinition("bitbots_dynup", true),
+    new PackageDefinition("bitbots_hcm", true),
+    new PackageDefinition("bitbots_odometry", true),
+    new PackageDefinition("bitbots_recordui_rqt", true),
+    new PackageDefinition("bitbots_splines", true)
 ] as PackageDefinition[])


### PR DESCRIPTION
This adds all `bitbots_motion` package to the Jenkinsfile to add them to the automatic build system. They will not all build rightaway but after some iterations they should all build.