### PR TITLE
visualization: add orientation for splines

### DIFF
--- a/bitbots_dynamic_kick/package.xml
+++ b/bitbots_dynamic_kick/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_dynamic_kick</name>
-  <version>0.1.4</version>
+  <version>0.1.5</version>
   <description>
 	  The bitbots_dynamic_kick package implements a kick which is not based on keyframe animations.
 	  Instead it aims to dynamically reach it's movement goal while keeping the robot stable and controllable.

--- a/bitbots_dynamic_kick/src/visualizer.cpp
+++ b/bitbots_dynamic_kick/src/visualizer.cpp
@@ -14,9 +14,9 @@ Visualizer::Visualizer(const std::string &base_topic) :
   /* create necessary publishers */
   goal_publisher_ = node_handle_.advertise<visualization_msgs::Marker>(base_topic_ + "received_goal",
       /* queue_size */ 5, /* latch */ true);
-  foot_spline_publisher_ = node_handle_.advertise<visualization_msgs::Marker>(base_topic_ + "flying_foot_spline",
+  foot_spline_publisher_ = node_handle_.advertise<visualization_msgs::MarkerArray>(base_topic_ + "flying_foot_spline",
       /* queue_size */ 5, /* latch */ true);
-  trunk_spline_publisher_ = node_handle_.advertise<visualization_msgs::Marker>(base_topic_ + "trunk_spline",
+  trunk_spline_publisher_ = node_handle_.advertise<visualization_msgs::MarkerArray>(base_topic_ + "trunk_spline",
       /* queue_size */ 5, /* latch */ true);
   windup_publisher_ = node_handle_.advertise<visualization_msgs::Marker>(base_topic_ + "kick_windup_point",
       /* queue_size */ 5, /* latch */ true);
@@ -31,8 +31,8 @@ void Visualizer::displayFlyingSplines(bitbots_splines::PoseSpline splines,
   if (foot_spline_publisher_.getNumSubscribers() == 0)
     return;
 
-  visualization_msgs::Marker path = getPath(splines, support_foot_frame, params_.spline_smoothness);
-  path.color.g = 1;
+  visualization_msgs::MarkerArray path = getPath(splines, support_foot_frame, params_.spline_smoothness);
+  path.markers[0].color.g = 1;
 
   foot_spline_publisher_.publish(path);
 }
@@ -41,8 +41,8 @@ void Visualizer::displayTrunkSplines(bitbots_splines::PoseSpline splines) {
   if (trunk_spline_publisher_.getNumSubscribers() == 0)
     return;
 
-  visualization_msgs::Marker path = getPath(splines, "base_link", params_.spline_smoothness);
-  path.color.g = 1;
+  visualization_msgs::MarkerArray path = getPath(splines, "base_link", params_.spline_smoothness);
+  path.markers[0].color.g = 1;
 
   trunk_spline_publisher_.publish(path);
 }

--- a/bitbots_splines/include/bitbots_splines/abstract_visualizer.h
+++ b/bitbots_splines/include/bitbots_splines/abstract_visualizer.h
@@ -3,6 +3,7 @@
 
 #include <tf2/LinearMath/Vector3.h>
 #include <visualization_msgs/Marker.h>
+#include <visualization_msgs/MarkerArray.h>
 #include <bitbots_splines/pose_spline.h>
 
 namespace bitbots_splines {
@@ -38,39 +39,97 @@ class AbstractVisualizer {
 
   /**
    * Utility function to create a visualization marker for a trajectory with default properties.
-   * @param splines A PoseSpline containing the splines to be displayed
+   * @param spline A PoseSpline containing the splines to be displayed
    * @param frame The frame in which the splines are given
    * @param smoothness The smoothness of the splines
-   * @return The visualization marker
+   * @return The visualization markers
    */
-  visualization_msgs::Marker getPath(bitbots_splines::PoseSpline &splines,
+  visualization_msgs::MarkerArray getPath(bitbots_splines::PoseSpline &spline,
                                      const std::string &frame,
                                      const double smoothness) {
-    visualization_msgs::Marker marker;
-    marker.action = visualization_msgs::Marker::ADD;
-    marker.type = visualization_msgs::Marker::LINE_STRIP;
-    marker.lifetime = ros::Duration(1000);
-    marker.frame_locked = false;
-    marker.header.frame_id = frame;
-    marker.header.stamp = ros::Time::now();
-    marker.pose.orientation.w = 1;
-    marker.scale.x = 0.01;
-    marker.color.a = 1;
+
+    visualization_msgs::MarkerArray marker_array;
+    visualization_msgs::Marker base_marker;
+    base_marker.action = visualization_msgs::Marker::ADD;
+    base_marker.lifetime = ros::Duration(1000);
+    base_marker.frame_locked = true;
+    base_marker.header.frame_id = frame;
+    base_marker.header.stamp = ros::Time::now();
+    base_marker.pose.orientation.w = 1;
+    base_marker.color.a = 1;
+    int id = 0;
+
+    // Marker for spline path
+    visualization_msgs::Marker path_marker = base_marker;
+    path_marker.type = visualization_msgs::Marker::LINE_STRIP;
+    path_marker.id = id++;
+    path_marker.scale.x = 0.01;
 
     // Take length of spline, assuming values at the beginning and end are set for x
-    double first_time = splines.x()->min();
-    double last_time = splines.x()->max();
+    double first_time = spline.x()->min();
+    double last_time = spline.x()->max();
 
+    // Iterate over splines, get points everywhere
+    // Taking the manually set points is not enough because velocities and accelerations influence the curve
     for (double i = first_time; i <= last_time; i += (last_time - first_time) / smoothness) {
       geometry_msgs::Point point;
-      point.x = splines.x()->pos(i);
-      point.y = splines.y()->pos(i);
-      point.z = splines.z()->pos(i);
+      point.x = spline.x()->pos(i);
+      point.y = spline.y()->pos(i);
+      point.z = spline.z()->pos(i);
 
-      marker.points.push_back(point);
+      path_marker.points.push_back(point);
     }
+    marker_array.markers.push_back(path_marker);
 
-    return marker;
+    // Marker for spline orientation
+    // Get all times of manually added points
+    std::list<double> times;
+    for (const SmoothSpline::Point &p : spline.roll()->points()) {
+      times.push_back(p.time);
+    }
+    for (const SmoothSpline::Point &p : spline.pitch()->points()) {
+      times.push_back(p.time);
+    }
+    for (const SmoothSpline::Point &p : spline.yaw()->points()) {
+      times.push_back(p.time);
+    }
+    times.sort();
+    times.unique();
+
+    visualization_msgs::Marker orientation_marker = base_marker;
+    orientation_marker.scale.x = 0.05;
+    orientation_marker.scale.y = 0.005;
+    orientation_marker.scale.z = 0.005;
+    orientation_marker.type = visualization_msgs::Marker::ARROW;
+    for (double time : times) {
+      orientation_marker.id = id++;
+      orientation_marker.pose.position = spline.getGeometryMsgPosition(time);
+
+      // We use three axes for every orientation
+      // x
+      orientation_marker.color.b = 0;
+      orientation_marker.color.r = 1;
+      tf2::Quaternion x_rotation = spline.getOrientation(time) * tf2::Vector3(1, 0, 0);
+      orientation_marker.pose.orientation = tf2::toMsg(x_rotation.normalize());
+      marker_array.markers.push_back(orientation_marker);
+
+      // y
+      orientation_marker.color.r = 0;
+      orientation_marker.color.g = 1;
+      tf2::Quaternion y_rotation = spline.getOrientation(time) * tf2::Vector3(1, 1, 0);
+      orientation_marker.pose.orientation = tf2::toMsg(y_rotation.normalize());
+      orientation_marker.id = id++;
+      marker_array.markers.push_back(orientation_marker);
+
+      // z
+      orientation_marker.color.g = 0;
+      orientation_marker.color.b = 1;
+      tf2::Quaternion z_rotation = spline.getOrientation(time) * tf2::Vector3(1, 0, 1);
+      orientation_marker.pose.orientation = tf2::toMsg(z_rotation.normalize());
+      orientation_marker.id = id++;
+      marker_array.markers.push_back(orientation_marker);
+    }
+    return marker_array;
   }
 };
 }

--- a/bitbots_splines/package.xml
+++ b/bitbots_splines/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_splines</name>
-  <version>1.0.1</version>
+  <version>1.1.0</version>
   <description>This package provides a library for splines which is based on the code by team Rhoban FC</description>
 
   <maintainer email="bestmann@informatik.uni-hamburg.de">Marc Bestmann</maintainer>


### PR DESCRIPTION
## Proposed changes
This adds a visualization for spline orientations:

![kick_spline_orientation_visualization](https://user-images.githubusercontent.com/25013222/73969608-06c97780-491c-11ea-8dc2-69b42dcdb20d.png)


## Necessary checks
- [x] Update package version
- [x] Run linters
- [x] Run `catkin build`
- [ ] Write documentation
- [x] Test on your machine
- [ ] ~~Test on the robot~~

