### PR TITLE
Fix: Odometry fuser Z axis

### DIFF
--- a/bitbots_odometry/CMakeLists.txt
+++ b/bitbots_odometry/CMakeLists.txt
@@ -13,11 +13,14 @@ find_package(catkin REQUIRED COMPONENTS
   tf2
   tf2_ros
   tf2_geometry_msgs
+  tf2_eigen
   geometry_msgs
   roscpp
   bitbots_docs
+  rotconv
 )
 
+find_package(Eigen3 REQUIRED)
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
 
@@ -110,7 +113,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES bitbots_odometry
-   CATKIN_DEPENDS nav_msgs sensor_msgs tf2
+   CATKIN_DEPENDS nav_msgs sensor_msgs tf2 rotconv
 #  DEPENDS system_lib
 )
 
@@ -123,6 +126,7 @@ catkin_package(
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
+  ${Eigen3_INCLUDE_DIRS}
 )
 
 ## Declare a C++ library
@@ -154,6 +158,7 @@ add_executable(motion_odometry src/motion_odometry.cpp)
 ## Specify libraries to link a library or executable target against
 target_link_libraries(odometry_fuser
   ${catkin_LIBRARIES}
+  ${Eigen3_LIBRARIES}
 )
 
 target_link_libraries(motion_odometry

--- a/bitbots_odometry/include/bitbots_odometry/odometry_fuser.h
+++ b/bitbots_odometry/include/bitbots_odometry/odometry_fuser.h
@@ -2,6 +2,7 @@
 #include <ros/console.h>
 #include <sensor_msgs/Imu.h>
 #include <tf2_ros/transform_broadcaster.h>
+#include <tf2_eigen/tf2_eigen.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <geometry_msgs/TransformStamped.h>
 #include <nav_msgs/Odometry.h>
@@ -10,6 +11,7 @@
 #include <tf2/utils.h>
 #include <tf2_ros/transform_listener.h>
 #include <tf2/LinearMath/Vector3.h>
+#include <tf2/LinearMath/Scalar.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/LinearMath/Transform.h>
 
@@ -30,5 +32,6 @@ class OdometryFuser {
   void imuCallback(const sensor_msgs::Imu::ConstPtr &msg);
   void odomCallback(const nav_msgs::Odometry::ConstPtr &msg);
   void supportCallback(const std_msgs::Char::ConstPtr &msg);
+  tf2::Quaternion getCurrentZImuRotation(tf2::Quaternion imu_rotation);
   tf2::Transform getCurrentRotationPoint();
 };

--- a/bitbots_odometry/include/bitbots_odometry/odometry_fuser.h
+++ b/bitbots_odometry/include/bitbots_odometry/odometry_fuser.h
@@ -28,10 +28,13 @@ class OdometryFuser {
   char current_support_state_;
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
+  tf2::Quaternion last_quat_;
+  tf2::Quaternion last_quat_imu_;
 
   void imuCallback(const sensor_msgs::Imu::ConstPtr &msg);
   void odomCallback(const nav_msgs::Odometry::ConstPtr &msg);
   void supportCallback(const std_msgs::Char::ConstPtr &msg);
-  tf2::Quaternion getCurrentZImuRotation(tf2::Quaternion imu_rotation);
+  tf2::Quaternion getCurrentMotionOdomYaw(tf2::Quaternion motion_odom_rotation);
+  tf2::Quaternion getCurrentImuRotationWithoutYaw(tf2::Quaternion imu_rotation);
   tf2::Transform getCurrentRotationPoint();
 };

--- a/bitbots_odometry/include/bitbots_odometry/odometry_fuser.h
+++ b/bitbots_odometry/include/bitbots_odometry/odometry_fuser.h
@@ -14,6 +14,8 @@
 #include <tf2/LinearMath/Scalar.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/LinearMath/Transform.h>
+#include <Eigen/Geometry>
+#include <rot_conv/rot_conv.h>
 
 
 class OdometryFuser {

--- a/bitbots_odometry/package.xml
+++ b/bitbots_odometry/package.xml
@@ -13,15 +13,11 @@
   <author email="jasper@bit-bots.de">Jasper Güldenstein</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>nav_msgs</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>tf2</build_depend>
-  <build_export_depend>nav_msgs</build_export_depend>
-  <build_export_depend>sensor_msgs</build_export_depend>
-  <build_export_depend>tf2</build_export_depend>
-  <exec_depend>nav_msgs</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>tf2</exec_depend>
+  <depend>nav_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_eigen</depend>
+  <depend>rotconv</depend>
   <depend>bitbots_docs</depend>
 
   <export>

--- a/bitbots_odometry/src/odometry_fuser.cpp
+++ b/bitbots_odometry/src/odometry_fuser.cpp
@@ -1,6 +1,4 @@
 #include <bitbots_odometry/odometry_fuser.h>
-#include <rot_conv/rot_conv.h>
-#include <Eigen/Geometry>
 
 /*
 odom -> baselink

--- a/bitbots_odometry/src/odometry_fuser.cpp
+++ b/bitbots_odometry/src/odometry_fuser.cpp
@@ -91,32 +91,24 @@ OdometryFuser::OdometryFuser() : tf_listener_(tf_buffer_) {
         br.sendTransform(rotation_point_msg);
         // get base_link in rotation point frame
         tf2::Transform base_link_in_rotation_point = rotation_point_in_base.inverse();
-        // create transform that rotates around IMU roll,pitch and walk yaw
-        tf2::Transform rotation;
-        rotation.setRotation(imu_orientation);
-        rotation.setOrigin({0, 0, 0});
-
 
         // get only translation and yaw from motion odometry
-        tf2::Quaternion odom_orientation = motion_odometry.getRotation();
-        tf2::Matrix3x3 odom_rotation_matrix(odom_orientation);
-        odom_rotation_matrix.getRPY(placeholder, placeholder, walking_yaw);
+        tf2::Quaternion odom_orientation_yaw = getCurrentMotionOdomYaw(
+          motion_odometry.getRotation());
         tf2::Transform motion_odometry_yaw;
-        tf2::Quaternion odom_orientation_yaw;
-        odom_orientation_yaw.setRPY(0, 0, walking_yaw);
         motion_odometry_yaw.setRotation(odom_orientation_yaw);
         motion_odometry_yaw.setOrigin(motion_odometry.getOrigin());
 
-        tf2::Quaternion aaaaa = getCurrentZImuRotation(imu_orientation);;
-
-        tf2::Transform imu_y;
-        imu_y.setRotation(aaaaa);
-        imu_y.setOrigin({0, 0, 0});
+        // get imu transform without yaw
+        tf2::Quaternion imu_orientation_without_yaw_component = getCurrentImuRotationWithoutYaw(imu_orientation);
+        tf2::Transform imu_without_yaw_component;
+        imu_without_yaw_component.setRotation(imu_orientation_without_yaw_component);
+        imu_without_yaw_component.setOrigin({0, 0, 0});
 
         // transformation chain to get correctly rotated odom frame
         // go to the rotation point in the odom frame. rotate the transform to the base link at this point
         // fused_odometry = motion_odometry_yaw * rotation_point_in_base * rotation * base_link_in_rotation_point;
-        fused_odometry = motion_odometry_yaw  * rotation_point_in_base * imu_y * base_link_in_rotation_point ;
+        fused_odometry = motion_odometry_yaw * rotation_point_in_base * imu_without_yaw_component * base_link_in_rotation_point ;
       } else {
         fused_odometry = motion_odometry;
       }
@@ -138,37 +130,49 @@ OdometryFuser::OdometryFuser() : tf_listener_(tf_buffer_) {
   }
 }
 
-tf2::Quaternion OdometryFuser::getCurrentZImuRotation(tf2::Quaternion imu_rotation)
+tf2::Quaternion OdometryFuser::getCurrentMotionOdomYaw(tf2::Quaternion motion_odom_rotation)
 {
-  double placeholder, pitch;
-  tf2::Vector3 world_plane_Z_normal = tf2::Vector3(0,0,1);
-  tf2::Vector3 world_front = tf2::Vector3(1,0,0);
-
-  tf2::Vector3 robot_vector = tf2::Vector3(0,0,1);
-
-  tf2::Vector3 robot_vector_rotated =  robot_vector.rotate(imu_rotation.getAxis(), imu_rotation.getAngle()).normalize();
-
-  double dist = robot_vector_rotated.dot(world_plane_Z_normal);
-
-  tf2::Vector3 point_in_plane = robot_vector_rotated - dist * world_plane_Z_normal;
-
-  double z_angle = point_in_plane.angle(world_front);
-
-  double dot = point_in_plane.dot(world_front);
-  double det = point_in_plane.x()*world_front.y() - world_front.x()*point_in_plane.y();
-  z_angle = -atan2(det, dot);
-
-
+  // Convert tf to eigen quaternion
   Eigen::Quaterniond eigen_quat, out;
+  tf2::convert(motion_odom_rotation, eigen_quat);
+
+  // Extract yaw rotation
+  double yaw = rot_conv::EYawOfQuat(eigen_quat);
+
+  tf2::Quaternion odom_orientation_yaw;
+  odom_orientation_yaw.setRPY(0, 0, yaw);
+
+  return odom_orientation_yaw;
+}
+
+tf2::Quaternion OdometryFuser::getCurrentImuRotationWithoutYaw(tf2::Quaternion imu_rotation)
+{
+  // Calculate robot orientation vector
+  tf2::Vector3 robot_vector = tf2::Vector3(0,0,1);
+  tf2::Vector3 robot_vector_rotated = robot_vector.rotate(imu_rotation.getAxis(), imu_rotation.getAngle()).normalize();
+
+  // Check if the robots orientation is near the yaw singulateri
+  if (robot_vector_rotated.z() < 0.2)
+  {
+    // Use ony a IMU offset during the singulateri
+    return last_quat_ + ( imu_rotation - last_quat_imu_);
+  }
+
+  // Convert tf to eigen quaternion
+  Eigen::Quaterniond eigen_quat, eigen_quat_out;
   tf2::convert(imu_rotation, eigen_quat);
 
-  rot_conv::QuatNoEYaw(eigen_quat, out);
+  // Remove yaw from quaternion
+  rot_conv::QuatNoEYaw(eigen_quat, eigen_quat_out);
 
-  tf2::Quaternion a;
+  // Convert eigen to tf quaternion
+  tf2::Quaternion tf_quat_out;
 
-  tf2::convert(out, a);
+  tf2::convert(eigen_quat_out, tf_quat_out);
 
-  return a;
+  last_quat_ = tf_quat_out;
+  last_quat_imu_ = imu_rotation;
+  return tf_quat_out;
 }
 
 tf2::Transform OdometryFuser::getCurrentRotationPoint() {
@@ -204,10 +208,12 @@ tf2::Transform OdometryFuser::getCurrentRotationPoint() {
       tf2::Transform l_to_center_tf;
       l_to_center_tf
           .setOrigin({l_to_r_sole_tf.getOrigin().x() /2, l_to_r_sole_tf.getOrigin().y() /2, l_to_r_sole_tf.getOrigin().z() /2});
-      // Set 0 rotation, because the rotation measurement is done by the imu
+
+      // Set to zero rotation, because the rotation measurement is done by the imu
       tf2::Quaternion zero_rotation;
       zero_rotation.setRPY(0,0,0);
       l_to_center_tf.setRotation(zero_rotation);
+
       rotation_point_tf = base_to_l_sole_tf * l_to_center_tf;
       rotation_point_tf.setRotation(zero_rotation);
     } else {

--- a/bitbots_odometry/src/odometry_fuser.cpp
+++ b/bitbots_odometry/src/odometry_fuser.cpp
@@ -107,7 +107,6 @@ OdometryFuser::OdometryFuser() : tf_listener_(tf_buffer_) {
 
         // transformation chain to get correctly rotated odom frame
         // go to the rotation point in the odom frame. rotate the transform to the base link at this point
-        // fused_odometry = motion_odometry_yaw * rotation_point_in_base * rotation * base_link_in_rotation_point;
         fused_odometry = motion_odometry_yaw * rotation_point_in_base * imu_without_yaw_component * base_link_in_rotation_point ;
       } else {
         fused_odometry = motion_odometry;

--- a/bitbots_odometry/src/odometry_fuser.cpp
+++ b/bitbots_odometry/src/odometry_fuser.cpp
@@ -64,10 +64,10 @@ OdometryFuser::OdometryFuser() : tf_listener_(tf_buffer_) {
 
     if (imu_active || odom_active) {
       double walking_yaw, placeholder;
+
       // get roll an pitch from imu
       tf2::Quaternion imu_orientation;
       tf2::fromMsg(_imu_data.orientation, imu_orientation);
-      tf2::Matrix3x3 imu_rotation_matrix(imu_orientation);
 
       // get motion_odom transform
       tf2::Transform motion_odometry;

--- a/bitbots_odometry/src/odometry_fuser.cpp
+++ b/bitbots_odometry/src/odometry_fuser.cpp
@@ -97,7 +97,7 @@ OdometryFuser::OdometryFuser() : tf_listener_(tf_buffer_) {
         motion_odometry_yaw.setRotation(odom_orientation_yaw);
         motion_odometry_yaw.setOrigin(motion_odometry.getOrigin());
 
-        // get imu transform without yaw // TODO !!!!! IMU to base_link transform
+        // Get the rotation offset between the IMU and the baselink
         tf2::Transform imu_mounting_offset;
         try {
           geometry_msgs::TransformStamped imu_mounting_transform = tf_buffer_.lookupTransform(
@@ -107,6 +107,7 @@ OdometryFuser::OdometryFuser() : tf_listener_(tf_buffer_) {
           ROS_ERROR("Not able to use the IMU%s", ex.what());
         }
 
+        // get imu transform without yaw
         tf2::Quaternion imu_orientation_without_yaw_component = getCurrentImuRotationWithoutYaw(
           imu_orientation * imu_mounting_offset.getRotation());
         tf2::Transform imu_without_yaw_component;

--- a/bitbots_odometry/src/odometry_fuser.cpp
+++ b/bitbots_odometry/src/odometry_fuser.cpp
@@ -164,7 +164,7 @@ tf2::Quaternion OdometryFuser::getCurrentImuRotationWithoutYaw(tf2::Quaternion i
   if (robot_vector_rotated.z() < 0.2)
   {
     // Use ony a IMU offset during the singulateri
-    return last_quat_ + ( imu_rotation - last_quat_imu_);
+    return imu_rotation;
   }
 
   // Convert tf to eigen quaternion


### PR DESCRIPTION
This pull request mostly removes the usage of Euler coordinates from the odometry fuser.
This also implements the rot_conv library for this task.

## Proposed changes
Use quaternions for yaw removal with the rot_conv library.

## Related issues
#129 

## Necessary checks
- [ ] Update package version
- [x] Run linters
- [x] Run `catkin build`
- [x] Write documentation
- [x] Test on your machine
- [x] Test on the robot

