### PR TITLE
splines: make joint_goals_update and joint_goals_update_diff inline

### DIFF
--- a/bitbots_splines/include/bitbots_splines/abstract_ik.h
+++ b/bitbots_splines/include/bitbots_splines/abstract_ik.h
@@ -17,7 +17,7 @@ typedef std::pair<std::vector<std::string>, std::vector<double>> JointGoals;
  * @param values New values for the previously defined joint names
  * @return new joint goals with updated values
  */
-JointGoals joint_goals_update(const JointGoals &goals,
+inline JointGoals joint_goals_update(const JointGoals &goals,
                               const std::vector<std::string> &names,
                               const std::vector<double> &values) {
   JointGoals result = goals;
@@ -45,7 +45,7 @@ JointGoals joint_goals_update(const JointGoals &goals,
  * @param diffs Differences to be applied to the previously defined joint names
  * @return new joint goals with updated values
  */
-JointGoals joint_goals_update_diff(const JointGoals &goals,
+inline JointGoals joint_goals_update_diff(const JointGoals &goals,
                                    const std::vector<std::string> &names,
                                    const std::vector<double> &diffs) {
   JointGoals result = goals;


### PR DESCRIPTION
## Proposed changes
This pull request makes `joint_goals_update` and `joint_goals_update_diff` inline. This is necessary if we want to keep most of the splines library header-only because otherwise, the function is defined multiple times. It would probably make sense to move this to a separate cpp file, as well as the visualizer methods.

## Related issues
#134, #135 

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [x] Test on the robot
- [x] Put the PR on our Project board

