### PR TITLE
walk: introduce trunk movement in z direction

### DIFF
--- a/bitbots_quintic_walk/cfg/bitbots_quintic_walk_engine_params.cfg
+++ b/bitbots_quintic_walk/cfg/bitbots_quintic_walk_engine_params.cfg
@@ -84,7 +84,7 @@ group_engine_exper.add("first_step_swing_factor", double_t, 1,
 group_engine_exper.add("first_step_trunk_phase", double_t, 1,
                        "Trunk phase for the fist step", min=-1, max=1)
 group_engine_exper.add("trunk_z_movement", double_t, 1,
-                       "Amount of movement in z direction for trunk (around trunk_height) [m]", min=0, max=0.1)
+                       "Amount of movement in z direction for trunk (around trunk_height) [m]", min=-0.1, max=0.1)
 group_engine_exper.add("trunk_z_apex", double_t, 1,
                        "Trunk phase for z movement apex [0:1]", min=0, max=1)
 

--- a/bitbots_quintic_walk/cfg/bitbots_quintic_walk_engine_params.cfg
+++ b/bitbots_quintic_walk/cfg/bitbots_quintic_walk_engine_params.cfg
@@ -83,5 +83,10 @@ group_engine_exper.add("first_step_swing_factor", double_t, 1,
                 "Give extra swing to first step for better start", min=0, max=10)
 group_engine_exper.add("first_step_trunk_phase", double_t, 1,
                        "Trunk phase for the fist step", min=-1, max=1)
+group_engine_exper.add("trunk_z_movement", double_t, 1,
+                       "Amount of movement in z direction for trunk (around trunk_height) [m]", min=0, max=0.1)
+group_engine_exper.add("trunk_z_apex", double_t, 1,
+                       "Trunk phase for z movement apex [0:1]", min=0, max=1)
+
 
 exit(gen.generate(PACKAGE, "bitbots_quintic_walk", "bitbots_quintic_walk_engine_params"))

--- a/bitbots_quintic_walk/package.xml
+++ b/bitbots_quintic_walk/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_quintic_walk</name>
-  <version>1.1.3</version>
+  <version>1.2.0</version>
   <description>This is a simple open-loop walking engine which uses quintic splines to define the trajectories of both feet in cartesian space. An inverse kinematic is used to translate these into joint space. The parameters of the walking can be adjusted using dynamic_reconfigure.</description>
 
   <maintainer email="7engelke@informatik.uni-hamburg.de">Timon Engelke</maintainer>

--- a/bitbots_quintic_walk/src/walk_engine.cpp
+++ b/bitbots_quintic_walk/src/walk_engine.cpp
@@ -537,15 +537,15 @@ void WalkEngine::buildTrajectories(bool start_movement, bool start_step, bool ki
                               trunk_pos_vel_at_foot_change_.z(),
                               trunk_pos_acc_at_foot_change_.z());
   trunk_spline_.z()->addPoint(double_support_length + time_shift,
-                              params_.trunk_height)
+                              params_.trunk_height);
   trunk_spline_.z()->addPoint(double_support_length + time_shift + params_.trunk_z_apex,
-                              params_.trunk_height + params_.trunk_z_movement)
+                              params_.trunk_height + params_.trunk_z_movement);
   trunk_spline_.z()->addPoint(half_period + time_shift,
                               params_.trunk_height);
   trunk_spline_.z()->addPoint(half_period + double_support_length + time_shift,
-                              params_.trunk_height)
+                              params_.trunk_height);
   trunk_spline_.z()->addPoint(half_period + double_support_length + time_shift + params_.trunk_z_apex,
-                              params_.trunk_height + params_.trunk_z_movement)
+                              params_.trunk_height + params_.trunk_z_movement);
   trunk_spline_.z()->addPoint(period + time_shift,
                               params_.trunk_height);
 

--- a/bitbots_quintic_walk/src/walk_engine.cpp
+++ b/bitbots_quintic_walk/src/walk_engine.cpp
@@ -536,8 +536,16 @@ void WalkEngine::buildTrajectories(bool start_movement, bool start_step, bool ki
                               trunk_pos_at_foot_change_.z(),
                               trunk_pos_vel_at_foot_change_.z(),
                               trunk_pos_acc_at_foot_change_.z());
+  trunk_spline_.z()->addPoint(double_support_length + time_shift,
+                              params_.trunk_height)
+  trunk_spline_.z()->addPoint(double_support_length + time_shift + params_.trunk_z_apex,
+                              params_.trunk_height + params_.trunk_z_movement)
   trunk_spline_.z()->addPoint(half_period + time_shift,
                               params_.trunk_height);
+  trunk_spline_.z()->addPoint(half_period + double_support_length + time_shift,
+                              params_.trunk_height)
+  trunk_spline_.z()->addPoint(half_period + double_support_length + time_shift + params_.trunk_z_apex,
+                              params_.trunk_height + params_.trunk_z_movement)
   trunk_spline_.z()->addPoint(period + time_shift,
                               params_.trunk_height);
 


### PR DESCRIPTION
## Proposed changes
Introduces an experimental parameter for adding trunk movement in z direction. This could maybe lessen stress on support leg as it does not have to turn as much.
This is still highly experimental and therefore only a draft.

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [x] Write documentation
- [x] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

