### PR TITLE
Adapt recordui to python3 syntax changes

### DIFF
--- a/bitbots_recordui_rqt/package.xml
+++ b/bitbots_recordui_rqt/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>bitbots_recordui_rqt</name>
-  <version>0.0.1</version>
+  <version>1.0.0</version>
   <description>TODO
   </description>
 

--- a/bitbots_recordui_rqt/src/bitbots_recordui_rqt/animation_recording.py
+++ b/bitbots_recordui_rqt/src/bitbots_recordui_rqt/animation_recording.py
@@ -201,7 +201,7 @@ class Recorder(object):
         }
 
         for kf in anim['keyframes']:
-            for k, v in kf['goals'].iteritems():
+            for k, v in kf['goals'].items():
                 kf['goals'][k] = int(math.degrees(v))
 
         with open(path, "w") as fp:
@@ -249,7 +249,7 @@ class Recorder(object):
                         kf['name'] = 'frame'+str(i)
                         i += 1
                 for kf in data['keyframes']:
-                    for k, v in kf['goals'].iteritems():
+                    for k, v in kf['goals'].items():
                         kf['goals'][k] = math.radians(v)
             except ValueError as e:
                 rospy.logerr("Animation %s is corrupt:\n %s" %
@@ -263,7 +263,7 @@ class Recorder(object):
 
         self.save_step("Loading of animation named %s" % path)
 
-        self.current_state.anim_steps = data[u'keyframes']
+        self.current_state.anim_steps = data['keyframes']
 
     def play(self, anim_path, until_frame=None):
         ''' Record command, start playing an animation
@@ -289,7 +289,7 @@ class Recorder(object):
                 "keyframes": deepcopy(self.current_state.anim_steps[0:n])
             }
             for kf in anim_dict['keyframes']:
-                for k, v in kf['goals'].iteritems():
+                for k, v in kf['goals'].items():
                     kf['goals'][k] = int(math.degrees(v))
 
             rospy.loginfo("playing %d frames..." % len(anim_dict['keyframes']))

--- a/bitbots_recordui_rqt/src/bitbots_recordui_rqt/record_ui.py
+++ b/bitbots_recordui_rqt/src/bitbots_recordui_rqt/record_ui.py
@@ -143,7 +143,7 @@ class RecordUI(Plugin):
 
         self.update_time = rospy.Duration(0.1)
 
-        for k,v in self.ids.iteritems():
+        for k,v in self.ids.items():
             rospy.loginfo(k)
             self._initial_joints.name.append(k)
             self._initial_joints.position.append(0)
@@ -215,7 +215,8 @@ class RecordUI(Plugin):
             slider.setTickInterval(1)
             slider.setMinimum(-181)
             slider.setMaximum(181)
-            slider.valueChanged.connect(self.slider_update)
+            slider.sliderMoved.connect(self.slider_update) //This has to  be a sliderMoved signal, since valueChanged is
+                                                           //triggered by other sources than user action.
             self._sliders[k] = slider
 
             textfield = QLineEdit()
@@ -436,9 +437,9 @@ class RecordUI(Plugin):
         self.set_all_joints_stiff()
 
         if self._widget.frameList.currentItem().text() == "#CURRENT_FRAME":
-            for k, v in self._workingValues.iteritems():
+            for k, v in self._workingValues.items():
                 self._workingValues[k] = 0.0
-        for k, v in self._currentGoals.iteritems():
+        for k, v in self._currentGoals.items():
             self._currentGoals[k] = 0.0
         self.set_sliders_and_text_fields(manual=False)
 
@@ -664,7 +665,6 @@ class RecordUI(Plugin):
             self._selected_frame = None
 
 
-
             for v in self._recorder.get_animation_state():
                 if v["name"] == selected_frame_name:
                     self._selected_frame = v
@@ -712,7 +712,6 @@ class RecordUI(Plugin):
                 self._textFields[k].setEnabled(v)
                 self._sliders[k].setEnabled(v)
 
-        self.set_sliders_and_text_fields(manual=False)
         self.box_ticked()
 
     def motor_switcher(self):
@@ -843,6 +842,7 @@ class RecordUI(Plugin):
         Updates the text fields and sliders in self._sliders and self._textfields and also frame name and duration and pause 
         to the values in self._workingValues. 
         '''
+        print(self._workingValues)
         for k, v in self._workingValues.items():
             try:
                 if not self._treeItems[k].checkState(0) == 0:

--- a/bitbots_recordui_rqt/src/bitbots_recordui_rqt/record_ui.py
+++ b/bitbots_recordui_rqt/src/bitbots_recordui_rqt/record_ui.py
@@ -215,8 +215,8 @@ class RecordUI(Plugin):
             slider.setTickInterval(1)
             slider.setMinimum(-181)
             slider.setMaximum(181)
-            slider.sliderMoved.connect(self.slider_update) //This has to  be a sliderMoved signal, since valueChanged is
-                                                           //triggered by other sources than user action.
+            slider.sliderMoved.connect(self.slider_update) # This has to  be a sliderMoved signal, since valueChanged is
+                                                           # triggered by other sources than user action.
             self._sliders[k] = slider
 
             textfield = QLineEdit()
@@ -842,7 +842,6 @@ class RecordUI(Plugin):
         Updates the text fields and sliders in self._sliders and self._textfields and also frame name and duration and pause 
         to the values in self._workingValues. 
         '''
-        print(self._workingValues)
         for k, v in self._workingValues.items():
             try:
                 if not self._treeItems[k].checkState(0) == 0:


### PR DESCRIPTION
## Proposed changes
Changes iteritems() to items() and valueChanged signal to sliderMoved signal.

## Related issues
Fixes issue #139 

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

