### PR TITLE
Walk: Phase resetting via joint effort

### DIFF
--- a/bitbots_quintic_walk/cfg/bitbots_quintic_walk_params.cfg
+++ b/bitbots_quintic_walk/cfg/bitbots_quintic_walk_params.cfg
@@ -25,13 +25,18 @@ group_node.add("odom_pub_factor", int_t, 1,
 group_node.add("ik_timeout", double_t, 1,
                "Timeout time for bioIK [s]", min=0, max=0.05)
 
-group_reset.add("phase_reset_active", bool_t, 1,
-                "Activates phase resetting when foot gets ground contact")
+group_reset.add("pressure_phase_reset_active", bool_t, 1,
+                "Activates phase resetting when foot sensor gets ground contact")
 group_reset.add("ground_min_pressure", double_t, 1,
                 "Minimal pressure on flying foot to say that it has contact to the ground. Used to invoke phase reset.",
                 min=0, max=10)
 group_reset.add("phase_reset_phase", double_t, 1,
                 "Minimal phase distance to end of step to invoke phase reset", min=0, max=1)
+group_reset.add("joint_min_effort", double_t, 1,
+                "Minimal effort on flying leg joints to say that it has contact to the ground. Used to invoke phase reset.",
+                min=0, max=10)
+group_reset.add("joint_phase_reset_active", bool_t, 1,
+                "Activates phase resetting when leg ground contact, by sensing joint forces")
 
 group_stability.add("pause_duration", double_t, 1,
                     "Time that the walking is paused when becoming unstable [s]", min=0, max=10)

--- a/bitbots_quintic_walk/cfg/bitbots_quintic_walk_params.cfg
+++ b/bitbots_quintic_walk/cfg/bitbots_quintic_walk_params.cfg
@@ -34,7 +34,7 @@ group_reset.add("phase_reset_phase", double_t, 1,
                 "Minimal phase distance to end of step to invoke phase reset", min=0, max=1)
 group_reset.add("joint_min_effort", double_t, 1,
                 "Minimal effort on flying leg joints to say that it has contact to the ground. Used to invoke phase reset.",
-                min=0, max=10)
+                min=0, max=100)
 group_reset.add("joint_phase_reset_active", bool_t, 1,
                 "Activates phase resetting when leg ground contact, by sensing joint forces")
 

--- a/bitbots_quintic_walk/cfg/bitbots_quintic_walk_params.cfg
+++ b/bitbots_quintic_walk/cfg/bitbots_quintic_walk_params.cfg
@@ -35,7 +35,7 @@ group_reset.add("phase_reset_phase", double_t, 1,
 group_reset.add("joint_min_effort", double_t, 1,
                 "Minimal effort on flying leg joints to say that it has contact to the ground. Used to invoke phase reset.",
                 min=0, max=100)
-group_reset.add("joint_phase_reset_active", bool_t, 1,
+group_reset.add("effort_phase_reset_active", bool_t, 1,
                 "Activates phase resetting when leg ground contact, by sensing joint forces")
 
 group_stability.add("pause_duration", double_t, 1,

--- a/bitbots_quintic_walk/config/walking_wolfgang_robot.yaml
+++ b/bitbots_quintic_walk/config/walking_wolfgang_robot.yaml
@@ -103,7 +103,7 @@ walking:
     ground_min_pressure: 1.5
     phase_reset_phase: 0.25
     joint_min_effort: 35
-    joint_phase_reset_active: False
+    effort_phase_reset_active: False
 
     publish_odom_tf: False
 

--- a/bitbots_quintic_walk/config/walking_wolfgang_robot.yaml
+++ b/bitbots_quintic_walk/config/walking_wolfgang_robot.yaml
@@ -102,6 +102,8 @@ walking:
     phase_reset_active: True
     ground_min_pressure: 1.5
     phase_reset_phase: 0.25
+    joint_min_effort: 35
+    joint_phase_reset_active: False
 
     publish_odom_tf: False
 

--- a/bitbots_quintic_walk/config/walking_wolfgang_simulator.yaml
+++ b/bitbots_quintic_walk/config/walking_wolfgang_simulator.yaml
@@ -102,6 +102,8 @@ walking:
     phase_reset_active: False
     ground_min_pressure: 1.5
     phase_reset_phase: 0.25
+    joint_min_effort: 35
+    joint_phase_reset_active: True
 
     publish_odom_tf: False
 

--- a/bitbots_quintic_walk/config/walking_wolfgang_simulator.yaml
+++ b/bitbots_quintic_walk/config/walking_wolfgang_simulator.yaml
@@ -103,7 +103,7 @@ walking:
     ground_min_pressure: 1.5
     phase_reset_phase: 0.25
     joint_min_effort: 35
-    joint_phase_reset_active: True
+    effort_phase_reset_active: True
 
     publish_odom_tf: False
 

--- a/bitbots_quintic_walk/config/walking_wolfgang_viz.yaml
+++ b/bitbots_quintic_walk/config/walking_wolfgang_viz.yaml
@@ -103,7 +103,7 @@ walking:
     ground_min_pressure: 1.5
     phase_reset_phase: 0.25
     joint_min_effort: 35
-    joint_phase_reset_active: False
+    effort_phase_reset_active: False
 
     publish_odom_tf: False
 

--- a/bitbots_quintic_walk/config/walking_wolfgang_viz.yaml
+++ b/bitbots_quintic_walk/config/walking_wolfgang_viz.yaml
@@ -102,6 +102,8 @@ walking:
     phase_reset_active: True
     ground_min_pressure: 1.5
     phase_reset_phase: 0.25
+    joint_min_effort: 35
+    joint_phase_reset_active: False
 
     publish_odom_tf: False
 

--- a/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_ik.h
+++ b/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_ik.h
@@ -16,6 +16,9 @@ class WalkIK : public bitbots_splines::AbstractIK<WalkResponse> {
   void reset() override;
   void setIKTimeout(double timeout);
 
+  const std::vector<std::string>& getLeftLegJointNames();
+  const std::vector<std::string>& getRightLegJointNames();
+
  private:
   robot_state::RobotStatePtr goal_state_;
   const moveit::core::JointModelGroup *legs_joints_group_;

--- a/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_node.h
+++ b/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_node.h
@@ -115,7 +115,7 @@ class WalkNode {
   double engine_frequency_;
 
   bool pressure_phase_reset_active_;
-  bool joint_phase_reset_active_;
+  bool effort_phase_reset_active_;
   double phase_reset_phase_;
   double ground_min_pressure_;
   double joint_min_effort_;

--- a/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_node.h
+++ b/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_node.h
@@ -114,9 +114,11 @@ class WalkNode {
 
   double engine_frequency_;
 
-  bool phase_reset_active_;
+  bool pressure_phase_reset_active_;
+  bool joint_phase_reset_active_;
   double phase_reset_phase_;
   double ground_min_pressure_;
+  double joint_min_effort_;
   bool cop_stop_active_;
   double cop_x_threshold_;
   double cop_y_threshold_;
@@ -186,6 +188,7 @@ class WalkNode {
   double current_trunk_fused_roll_;
 
   double current_fly_pressure_;
+  double current_fly_effort_;
 
   double roll_vel_;
   double pitch_vel_;

--- a/bitbots_quintic_walk/package.xml
+++ b/bitbots_quintic_walk/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_quintic_walk</name>
-  <version>1.3.0</version>
+  <version>1.4.0</version>
   <description>This is a simple open-loop walking engine which uses quintic splines to define the trajectories of both feet in cartesian space. An inverse kinematic is used to translate these into joint space. The parameters of the walking can be adjusted using dynamic_reconfigure.</description>
 
   <maintainer email="7engelke@informatik.uni-hamburg.de">Timon Engelke</maintainer>

--- a/bitbots_quintic_walk/src/walk_ik.cpp
+++ b/bitbots_quintic_walk/src/walk_ik.cpp
@@ -78,4 +78,12 @@ void WalkIK::setIKTimeout(double timeout) {
   ik_timeout_ = timeout;
 }
 
+const std::vector<std::string>& WalkIK::getLeftLegJointNames(){
+  return left_leg_joints_group_->getJointModelNames();
+}
+
+const std::vector<std::string>& WalkIK::getRightLegJointNames(){
+  return right_leg_joints_group_->getJointModelNames();
+}
+
 } // namespace bitbots_quintic_walk

--- a/bitbots_quintic_walk/src/walk_node.cpp
+++ b/bitbots_quintic_walk/src/walk_node.cpp
@@ -263,7 +263,7 @@ void WalkNode::checkPhaseReset() {
       // reset phase by using pressure sensors
       ROS_WARN("Phase resetted by pressure!");
       walk_engine_.endStep();
-    }else if(joint_phase_reset_active_ && current_fly_effort_ > joint_min_effort_){
+    }else if(effort_phase_reset_active_ && current_fly_effort_ > joint_min_effort_){
       // reset phase by using joint efforts
       ROS_WARN("Phase resetted by effort!");
       walk_engine_.endStep();
@@ -325,7 +325,7 @@ void WalkNode::reconfCallback(bitbots_quintic_walk::bitbots_quintic_walk_paramsC
   imu_roll_vel_threshold_ = config.imu_roll_vel_threshold;
 
   pressure_phase_reset_active_ = config.pressure_phase_reset_active;
-  joint_phase_reset_active_ = config.joint_phase_reset_active;
+  effort_phase_reset_active_ = config.effort_phase_reset_active;
   phase_reset_phase_ = config.phase_reset_phase;
   ground_min_pressure_ = config.ground_min_pressure;
   joint_min_effort_ = config.joint_min_effort;

--- a/bitbots_quintic_walk/src/walk_node.cpp
+++ b/bitbots_quintic_walk/src/walk_node.cpp
@@ -291,7 +291,7 @@ void WalkNode::jointStateCb(const sensor_msgs::JointState &msg) {
     for (int i = 0; i < names.size(); i++) {
       // add effort on this joint to sum, if it is part of the flying leg
       if(std::find(fly_joint_names.begin(), fly_joint_names.end(), names[i]) != fly_joint_names.end()){
-          effort_sum = effort_sum + msg.effort[i];
+          effort_sum = effort_sum + abs(msg.effort[i]);
       }
     }
     current_fly_effort_ = effort_sum;

--- a/bitbots_quintic_walk/src/walk_node.cpp
+++ b/bitbots_quintic_walk/src/walk_node.cpp
@@ -254,12 +254,19 @@ void WalkNode::checkPhaseReset() {
   /**
    * This method checks, if the foot made contact to the ground and ends step earlier, by resetting the phase.
    */
-  // phase has to be far enough (almost at end of step) to have right foot lifted foot has to have ground contact
+  // phase has to be far enough (almost at end of step) so that the foot has already lifted from the ground
+  // otherwise we will always do phase reset in the beginning of the step
   double phase = walk_engine_.getPhase();
-  if (phase_reset_active_ && ((phase > 0.5 - phase_reset_phase_ && phase < 0.5) || (phase > 1 - phase_reset_phase_)) &&
-      current_fly_pressure_ > ground_min_pressure_) {
-    ROS_WARN("Phase resetted!");
-    walk_engine_.endStep();
+  if ((phase > 0.5 - phase_reset_phase_ && phase < 0.5) || (phase > 1 - phase_reset_phase_)) {
+    if(pressure_phase_reset_active_ && current_fly_pressure_ > ground_min_pressure_){
+      // reset phase by using pressure sensors
+      ROS_WARN("Phase resetted by pressure!");
+      walk_engine_.endStep();
+    }else if(joint_phase_reset_active_ && current_fly_effort_ > joint_min_effort_){
+      // reset phase by using joint efforts
+      ROS_WARN("Phase resetted by effort!");
+      walk_engine_.endStep();
+    }
   }
 }
 
@@ -274,6 +281,16 @@ void WalkNode::jointStateCb(const sensor_msgs::JointState &msg) {
     // besides its name, this method only changes a single joint position...
     current_state_->setJointPositions(names[i], &goals[i]);
   }
+  // compute the effort that is currently on the flying leg to check if it has ground contact
+  double effort_sum = 0;
+  const std::vector<std::string>& fly_joint_names = (walk_engine_.isLeftSupport()) ? ik_.getRightLegJointNames() : ik_.getLeftLegJointNames();
+  for (int i = 0; i < names.size(); i++) {
+    // add effort on this joint to sum, if it is part of the flying leg
+    if(std::find(fly_joint_names.begin(), fly_joint_names.end(), names[i]) != fly_joint_names.end()){
+        effort_sum = effort_sum + msg.effort[i];
+    }
+  }
+  current_fly_effort_ = effort_sum;
 }
 
 void WalkNode::kickCb(const std_msgs::BoolConstPtr &msg) {
@@ -300,9 +317,11 @@ void WalkNode::reconfCallback(bitbots_quintic_walk::bitbots_quintic_walk_paramsC
   imu_pitch_vel_threshold_ = config.imu_pitch_vel_threshold;
   imu_roll_vel_threshold_ = config.imu_roll_vel_threshold;
 
-  phase_reset_active_ = config.phase_reset_active;
+  pressure_phase_reset_active_ = config.pressure_phase_reset_active;
+  joint_phase_reset_active_ = config.joint_phase_reset_active;
   phase_reset_phase_ = config.phase_reset_phase;
   ground_min_pressure_ = config.ground_min_pressure;
+  joint_min_effort_ = config.joint_min_effort;
   params_.pause_duration = config.pause_duration;
   walk_engine_.setPauseDuration(params_.pause_duration);
 }


### PR DESCRIPTION
## Proposed changes
Adds a new option to use the joint effort information to check if the flying leg made ground contact (instead of pressure sensor).
Can be used on robots without pressure sensors, or as a fallback if foot sensors fail.


## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [x] Write documentation
- [x] Create issues for future work
- [x] Test on your machine
- [x] Test in simulation
- [x] Put the PR on our Project board

