### PR TITLE
walk: phase rest

### DIFF
--- a/bitbots_quintic_walk/cfg/bitbots_quintic_walk_params.cfg
+++ b/bitbots_quintic_walk/cfg/bitbots_quintic_walk_params.cfg
@@ -37,6 +37,9 @@ group_reset.add("joint_min_effort", double_t, 1,
                 min=0, max=100)
 group_reset.add("effort_phase_reset_active", bool_t, 1,
                 "Activates phase resetting when leg ground contact, by sensing joint forces")
+group_reset.add("phase_rest_active", bool_t, 1,
+                "Activates phase rest. Step will not be finished till a phase reset.")
+
 
 group_stability.add("pause_duration", double_t, 1,
                     "Time that the walking is paused when becoming unstable [s]", min=0, max=10)

--- a/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_engine.h
+++ b/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_engine.h
@@ -42,6 +42,13 @@ class WalkEngine : public bitbots_splines::AbstractEngine<WalkRequest, WalkRespo
   double getPhase() const;
 
   /**
+    * Returns the phase of one single step, on which we can start doing phase resets.
+      Basically the phase when the flying foot reached its apex.
+    */
+
+  double getPhaseResetPhase() const;
+
+  /**
    * Return current time between 0 and half period for trajectories evaluation
    */
   double getTrajsTime() const;
@@ -69,6 +76,8 @@ class WalkEngine : public bitbots_splines::AbstractEngine<WalkRequest, WalkRespo
    * Ends the current step earlier. Useful if foot hits ground to early.
    */
   void endStep();
+
+  void setPhaseRest(bool active);
 
   WalkState getState();
 
@@ -105,6 +114,9 @@ class WalkEngine : public bitbots_splines::AbstractEngine<WalkRequest, WalkRespo
   double time_paused_;
   double pause_duration_;
   bool pause_requested_;
+
+  // phase rest
+  bool phase_rest_active_;
 
   // kick handling
   bool left_kick_requested_;

--- a/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_node.h
+++ b/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_node.h
@@ -84,7 +84,7 @@ class WalkNode {
 
   void imuCb(const sensor_msgs::Imu &msg);
 
-  void checkPhaseReset();
+  void checkPhaseRestAndReset();
   void pressureRightCb(bitbots_msgs::FootPressure msg);
   void pressureLeftCb(bitbots_msgs::FootPressure msg);
 

--- a/bitbots_quintic_walk/package.xml
+++ b/bitbots_quintic_walk/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_quintic_walk</name>
-  <version>1.4.0</version>
+  <version>1.5.0</version>
   <description>This is a simple open-loop walking engine which uses quintic splines to define the trajectories of both feet in cartesian space. An inverse kinematic is used to translate these into joint space. The parameters of the walking can be adjusted using dynamic_reconfigure.</description>
 
   <maintainer email="7engelke@informatik.uni-hamburg.de">Timon Engelke</maintainer>

--- a/bitbots_quintic_walk/src/walk_engine.cpp
+++ b/bitbots_quintic_walk/src/walk_engine.cpp
@@ -67,7 +67,7 @@ WalkResponse WalkEngine::update(double dt) {
       // we are in idle and are not supposed to walk. current state is fine, just do nothing
       return createResponse();
     }
-  }else if(engine_state_ == WalkState::WALKING){
+  }else if (engine_state_ == WalkState::WALKING) {
     // check if the step would finish with this update of the phase
     bool step_will_finish = (phase_ < 0.5 && phase_ + dt * params_.freq > 0.5 ) || phase_ + dt * params_.freq > 1.0;
     // check if we should rest the phase because the flying foot didn't make contact to the ground during step

--- a/bitbots_quintic_walk/src/walk_engine.cpp
+++ b/bitbots_quintic_walk/src/walk_engine.cpp
@@ -15,6 +15,7 @@ WalkEngine::WalkEngine() :
     right_kick_requested_(false),
     time_paused_(0.0),
     pause_duration_(0.0),
+    phase_rest_active_(false),
     is_left_support_foot_(false),
     engine_state_(WalkState::IDLE) {
   left_in_world_.setIdentity();
@@ -42,7 +43,7 @@ WalkResponse WalkEngine::update(double dt) {
   // check if orders are zero, since we don't want to walk on the spot
   bool orders_zero = request_.orders.x() == 0 && request_.orders.y() == 0 && request_.orders.z() == 0;
 
-  // First check if we are currently in pause state or idle, since we don't want to update the phase in this case
+  // First check cases where we do not want to update the phase: pausing, idle and phase rest
   if (engine_state_ == WalkState::PAUSED) {
     if (time_paused_ > pause_duration_) {
       // our pause is finished, see if we can continue walking
@@ -64,6 +65,15 @@ WalkResponse WalkEngine::update(double dt) {
   } else if (engine_state_ == WalkState::IDLE) {
     if (orders_zero || !request_.walkable_state) {
       // we are in idle and are not supposed to walk. current state is fine, just do nothing
+      return createResponse();
+    }
+  }else if(engine_state_ == WalkState::WALKING){
+    // check if the step would finish with this update of the phase
+    bool step_will_finish = (phase_ < 0.5 && phase_ + dt * params_.freq > 0.5 ) || phase_ + dt * params_.freq > 1.0;
+    // check if we should rest the phase because the flying foot didn't make contact to the ground during step
+    if(step_will_finish && phase_rest_active_){
+      // dont update the phase (do a phase rest) till it gets updated by a phase reset
+      ROS_WARN("PHASE REST");
       return createResponse();
     }
   }
@@ -197,13 +207,17 @@ void WalkEngine::updatePhase(double dt) {
 }
 
 void WalkEngine::endStep() {
-  // ends the step earlier, e.g. when foot has already contact to gro
+  // ends the step earlier, e.g. when foot has already contact to ground
   // last_phase will still held the information about the time point where the reset occurred
   if (phase_ < 0.5) {
     phase_ = 0.5;
   } else {
     phase_ = 0.0;
   }
+}
+
+void WalkEngine::setPhaseRest(bool active){
+  phase_rest_active_ = active;
 }
 
 void WalkEngine::reset() {
@@ -775,6 +789,12 @@ WalkResponse WalkEngine::createResponse() {
 double WalkEngine::getPhase() const {
   return phase_;
 }
+
+double WalkEngine::getPhaseResetPhase() const{
+  // returning the phase when the foot is on apex in step phase (between 0 and 0.5)
+  return (params_.double_support_ratio + params_.foot_apex_phase * (1 - params_.double_support_ratio)) / 2;
+}
+
 
 double WalkEngine::getTrajsTime() const {
   double t;

--- a/bitbots_quintic_walk/src/walk_node.cpp
+++ b/bitbots_quintic_walk/src/walk_node.cpp
@@ -253,8 +253,8 @@ void WalkNode::pressureRightCb(const bitbots_msgs::FootPressure msg) {
 
 void WalkNode::checkPhaseRestAndReset() {
   /**
-   * This method checks, if the foot made contact to the ground and ends step earlier, by resetting the phase,
-     or let the robot rest until it makes contact.
+   * This method checks if the foot made contact to the ground and ends the step earlier by resetting the phase ("phase reset")
+     or lets the robot rest until it makes ground contact ("phase rest").
    */
   // phase has to be far enough (almost at end of step) so that the foot has already lifted from the ground
   // otherwise we will always do phase reset in the beginning of the step

--- a/bitbots_quintic_walk/src/walk_node.cpp
+++ b/bitbots_quintic_walk/src/walk_node.cpp
@@ -334,7 +334,7 @@ void WalkNode::reconfCallback(bitbots_quintic_walk::bitbots_quintic_walk_paramsC
   ground_min_pressure_ = config.ground_min_pressure;
   joint_min_effort_ = config.joint_min_effort;
   // phase rest can only work if one phase resetting method is active
-  if(joint_phase_reset_active_ || pressure_phase_reset_active_){
+  if(effort_phase_reset_active_ || pressure_phase_reset_active_){
     walk_engine_.setPhaseRest(config.phase_rest_active);
   }else{
     walk_engine_.setPhaseRest(false);


### PR DESCRIPTION
## Proposed changes
This adds a new stability option called "phase rest" that lets the walking rest at an end of a step until a phase reset occurs. This helps in situation where the robot is tilting to the side and the flying foot did not make ground contact during the step.

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [x] Write documentation
- [x] Create issues for future work
- [x] Test on your machine
- [x] Test in simulation
- [x] Put the PR on our Project board

