### PR TITLE
add launch files for dynup and kick

### DIFF
--- a/bitbots_dynamic_kick/launch/dynamic_kick.launch
+++ b/bitbots_dynamic_kick/launch/dynamic_kick.launch
@@ -1,0 +1,3 @@
+<launch>
+  <node pkg="bitbots_dynamic_kick" name="dynamic_kick" type="KickNode" output="screen" />
+</launch>

--- a/bitbots_dynamic_kick/package.xml
+++ b/bitbots_dynamic_kick/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_dynamic_kick</name>
-  <version>0.1.5</version>
+  <version>0.1.6</version>
   <description>
 	  The bitbots_dynamic_kick package implements a kick which is not based on keyframe animations.
 	  Instead it aims to dynamically reach it's movement goal while keeping the robot stable and controllable.

--- a/bitbots_dynup/launch/dynup.launch
+++ b/bitbots_dynup/launch/dynup.launch
@@ -1,0 +1,3 @@
+<launch>
+  <node pkg="bitbots_dynup" name="DynupNode" type="DynupNode" output="screen" />
+</launch>

--- a/bitbots_dynup/package.xml
+++ b/bitbots_dynup/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_dynup</name>
-  <version>0.0.2</version>
+  <version>0.0.6</version>
   <description>todo
   </description>
 


### PR DESCRIPTION
## Proposed changes
Since https://github.com/bit-bots/bitbots_misc/pull/63, a launch file for dynup is referenced in `motion.launch`. This launch file exists only on branch `feature/dynup-ba`. This PR adds a simple launch file for dynup and dynamic kick to make switching branches in the repo easier.

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

