### PR TITLE
Add upwards/downwards walking

### DIFF
--- a/bitbots_odometry/package.xml
+++ b/bitbots_odometry/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_odometry</name>
-  <version>1.0.8</version>
+  <version>1.0.9</version>
   <description>The bitbots_odometry package</description>
 
   <maintainer email="5guelden@informatik.uni-hamburg.de">Jasper Güldenstein</maintainer>

--- a/bitbots_odometry/src/motion_odometry.cpp
+++ b/bitbots_odometry/src/motion_odometry.cpp
@@ -60,7 +60,7 @@ MotionOdometry::MotionOdometry() {
           current_to_next_support.setOrigin({
                                                 current_to_next_support.getOrigin().x(),
                                                 current_to_next_support.getOrigin().y(),
-                                                0});
+                                                current_to_next_support.getOrigin().z()});
           tf2::Quaternion q;
           q.setRPY(0, 0, tf2::getYaw(current_to_next_support.getRotation()));
           current_to_next_support.setRotation(q);

--- a/bitbots_quintic_walk/cfg/bitbots_quintic_walk_params.cfg
+++ b/bitbots_quintic_walk/cfg/bitbots_quintic_walk_params.cfg
@@ -58,6 +58,8 @@ group_limits.add("max_step_y", double_t, 1,
 group_limits.add("max_step_xy", double_t, 1,
                  "Maximal step length in X and Y combined [m])", min=0, max=1)
 group_limits.add("max_step_z", double_t, 1,
+                 "Maximal step height in Z [m]", min=0, max=1)
+group_limits.add("max_step_angular", double_t, 1,
                  "Maximal step turn in yaw [rad])", min=0, max=1.5)
 
 

--- a/bitbots_quintic_walk/config/walking_wolfgang_robot.yaml
+++ b/bitbots_quintic_walk/config/walking_wolfgang_robot.yaml
@@ -86,7 +86,8 @@ walking:
     max_step_x: 0.06
     max_step_y: 0.05
     max_step_xy: 0.09
-    max_step_z: 0.45
+    max_step_z: 0.05
+    max_step_angular: 0.45
 
     vel: -1
     acc: -1

--- a/bitbots_quintic_walk/config/walking_wolfgang_robot_slow_steps.yaml
+++ b/bitbots_quintic_walk/config/walking_wolfgang_robot_slow_steps.yaml
@@ -86,7 +86,8 @@ walking:
     max_step_x: 0.06
     max_step_y: 0.05
     max_step_xy: 0.05
-    max_step_z: 0.4
+    max_step_z: 0.05
+    max_step_angular: 0.4
 
     vel: -1
     acc: -1

--- a/bitbots_quintic_walk/config/walking_wolfgang_simulator.yaml
+++ b/bitbots_quintic_walk/config/walking_wolfgang_simulator.yaml
@@ -86,7 +86,8 @@ walking:
     max_step_x: 0.06
     max_step_y: 0.05
     max_step_xy: 0.09
-    max_step_z: 0.45
+    max_step_z: 0.05
+    max_step_angular: 0.45
 
     vel: -1
     acc: -1

--- a/bitbots_quintic_walk/config/walking_wolfgang_viz.yaml
+++ b/bitbots_quintic_walk/config/walking_wolfgang_viz.yaml
@@ -86,7 +86,8 @@ walking:
     max_step_x: 0.06
     max_step_y: 0.05
     max_step_xy: 0.09
-    max_step_z: 0.45
+    max_step_z: 0.05
+    max_step_angular: 0.45
 
     vel: -1
     acc: -1

--- a/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_engine.h
+++ b/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_engine.h
@@ -175,7 +175,7 @@ class WalkEngine : public bitbots_splines::AbstractEngine<WalkRequest, WalkRespo
    * Zero vector means in place walking.
    * Special handle of lateral and turn step to avoid foot collision.
    */
-  void stepFromOrders(const tf2::Vector3 &diff);
+  void stepFromOrders(const tf2::Vector3 &linear_orders, double angular_z);
 
   /**
    * Small helper method to get euler angle instead of quaternion.

--- a/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_node.h
+++ b/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_node.h
@@ -146,7 +146,8 @@ class WalkNode {
    * Saves max values we can move in a single step as [x-direction, y-direction, z-rotation].
    * Is used to limit _currentOrders to sane values
    */
-  Eigen::Vector3d max_step_;
+  Eigen::Vector3d max_step_linear_;
+  double max_step_angular_;
 
   /**
    * Measures how much distance we can traverse in X and Y direction combined

--- a/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_utils.h
+++ b/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_utils.h
@@ -23,7 +23,8 @@ enum WalkState {
 };
 
 struct WalkRequest {
-  tf2::Vector3 orders = {0,0,0};
+  tf2::Vector3 linear_orders = {0,0,0};
+  double angular_z = 0;
   bool walkable_state = false;
 };
 

--- a/bitbots_quintic_walk/package.xml
+++ b/bitbots_quintic_walk/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_quintic_walk</name>
-  <version>1.4.0</version>
+  <version>1.5.0</version>
   <description>This is a simple open-loop walking engine which uses quintic splines to define the trajectories of both feet in cartesian space. An inverse kinematic is used to translate these into joint space. The parameters of the walking can be adjusted using dynamic_reconfigure.</description>
 
   <maintainer email="7engelke@informatik.uni-hamburg.de">Timon Engelke</maintainer>

--- a/bitbots_quintic_walk/src/walk_engine.cpp
+++ b/bitbots_quintic_walk/src/walk_engine.cpp
@@ -536,22 +536,26 @@ void WalkEngine::buildTrajectories(bool start_movement, bool start_step, bool ki
                                 trunk_apex_next.y());
   }
 
+  // When walking downwards, the correct trunk height is the one relative to the flying
+  // foot goal position, this results in lowering the trunk correctly during the step
+  double trunk_height_including_foot_z_movement = params_.trunk_height + std::min(0.0, support_to_next_.getOrigin().z());
+
   trunk_spline_.z()->addPoint(0.0,
                               trunk_pos_at_foot_change_.z(),
                               trunk_pos_vel_at_foot_change_.z(),
                               trunk_pos_acc_at_foot_change_.z());
   trunk_spline_.z()->addPoint(double_support_length + time_shift,
-                              params_.trunk_height);
+                              trunk_height_including_foot_z_movement);
   trunk_spline_.z()->addPoint(double_support_length + time_shift + params_.trunk_z_apex,
-                              params_.trunk_height + params_.trunk_z_movement);
+                              trunk_height_including_foot_z_movement + params_.trunk_z_movement);
   trunk_spline_.z()->addPoint(half_period + time_shift,
-                              params_.trunk_height);
+                              trunk_height_including_foot_z_movement);
   trunk_spline_.z()->addPoint(half_period + double_support_length + time_shift,
-                              params_.trunk_height);
+                              trunk_height_including_foot_z_movement);
   trunk_spline_.z()->addPoint(half_period + double_support_length + time_shift + params_.trunk_z_apex,
-                              params_.trunk_height + params_.trunk_z_movement);
+                              trunk_height_including_foot_z_movement + params_.trunk_z_movement);
   trunk_spline_.z()->addPoint(period + time_shift,
-                              params_.trunk_height);
+                              trunk_height_including_foot_z_movement);
 
   //Define trunk rotation as rool pitch yaw
   tf2::Vector3 euler_at_support = tf2::Vector3(

--- a/bitbots_quintic_walk/src/walk_engine.cpp
+++ b/bitbots_quintic_walk/src/walk_engine.cpp
@@ -420,7 +420,7 @@ void WalkEngine::buildTrajectories(bool start_movement, bool start_step, bool ki
   foot_spline_.z()->addPoint(0.0, foot_pos_at_foot_change_.z(),
                              foot_pos_vel_at_foot_change_.z(),
                              foot_pos_acc_at_foot_change_.z());
-  foot_spline_.z()->addPoint(double_support_length, 0);
+  foot_spline_.z()->addPoint(double_support_length, foot_pos_at_foot_change_.z());
   foot_spline_.z()->addPoint(double_support_length + single_support_length * params_.foot_apex_phase
                                  - 0.5 * params_.foot_z_pause * single_support_length,
                              params_.foot_rise);
@@ -428,8 +428,8 @@ void WalkEngine::buildTrajectories(bool start_movement, bool start_step, bool ki
                                  + 0.5 * params_.foot_z_pause * single_support_length,
                              params_.foot_rise);
   foot_spline_.z()->addPoint(double_support_length + single_support_length * params_.foot_put_down_phase,
-                             params_.foot_put_down_z_offset);
-  foot_spline_.z()->addPoint(half_period, 0.0);
+                             params_.foot_put_down_z_offset + support_to_next_.getOrigin().z());
+  foot_spline_.z()->addPoint(half_period, support_to_next_.getOrigin().z());
 
   //Flying foot orientation
   foot_spline_.roll()->addPoint(0.0, foot_orientation_pos_at_last_foot_change_.x(),
@@ -854,8 +854,9 @@ void WalkEngine::stepFromOrders(const tf2::Vector3 &linear_orders, double angula
   //Compute step diff in next support foot frame
   tf2::Transform tmp_diff = tf2::Transform();
   tmp_diff.setIdentity();
-  //No change in forward step
+  //No change in forward step and upward step
   tmp_diff.getOrigin()[0] = linear_orders.x();
+  tmp_diff.getOrigin()[2] = linear_orders.z();
   //Add lateral foot offset
   if (is_left_support_foot_) {
     tmp_diff.getOrigin()[1] += params_.foot_distance;


### PR DESCRIPTION
## Proposed changes
This PR adds the ability to walk upwards and downwards by setting the linear z component of the command velocities. It will be merged on the `running_robot_competition` branch.

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot

