### PR TITLE
Catch execution of unexisting animations correctly

### DIFF
--- a/bitbots_animation_server/package.xml
+++ b/bitbots_animation_server/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_animation_server</name>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <description>The bitbots_animation_server package provides an action server which interpolates keyframe animations and
   sends the next motor values to the hardware control manager.</description>
 

--- a/bitbots_animation_server/src/bitbots_animation_server/animation_node.py
+++ b/bitbots_animation_server/src/bitbots_animation_server/animation_node.py
@@ -86,7 +86,7 @@ class PlayAnimationAction(object):
         rate = rospy.Rate(200)
         start_time = rospy.get_time()
 
-        while not rospy.is_shutdown():
+        while not rospy.is_shutdown() and animator:
             # first check if we have another goal
             self.check_for_new_goal()
             new_goal = self._as.current_goal.goal.goal.animation


### PR DESCRIPTION

## Proposed changes
`animator` can be None when the animation does not exist, that must be checked for and the execution of the animation must be aborted.

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

