### PR TITLE
odom: reduce warnings

### DIFF
--- a/bitbots_odometry/package.xml
+++ b/bitbots_odometry/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_odometry</name>
-  <version>1.0.8</version>
+  <version>1.0.9</version>
   <description>The bitbots_odometry package</description>
 
   <maintainer email="5guelden@informatik.uni-hamburg.de">Jasper Güldenstein</maintainer>

--- a/bitbots_odometry/src/motion_odometry.cpp
+++ b/bitbots_odometry/src/motion_odometry.cpp
@@ -37,7 +37,7 @@ MotionOdometry::MotionOdometry() {
     //check if joint states were received, otherwise we can't provide odometry
     ros::Duration joints_delta_t = ros::Time::now() - joint_update_time_;
     if (joints_delta_t.toSec() > 0.05) {
-      ROS_WARN_THROTTLE(10, "No joint states received. Will not provide odometry.");
+      ROS_WARN_THROTTLE(30, "No joint states received. Will not provide odometry.");
     } else {
       // check if step finished, meaning left->right or right->left support. double support is skipped
       if ((current_support_state_ == 'l' && previous_support_state_ == 'r') ||

--- a/bitbots_odometry/src/odometry_fuser.cpp
+++ b/bitbots_odometry/src/odometry_fuser.cpp
@@ -39,7 +39,7 @@ OdometryFuser::OdometryFuser() : tf_listener_(tf_buffer_) {
 
   // wait for transforms from joints
   while (!tf_buffer_.canTransform("l_sole", "base_link", ros::Time(0), ros::Duration(1)) && ros::ok()) {
-    ROS_WARN("Wainting for transforms from robot joints");
+    ROS_WARN_THROTTLE(30, "Wainting for transforms from robot joints");
   }
 
   ros::Rate r(200.0);


### PR DESCRIPTION
## Proposed changes
Small fix against spam of warnings when robot is started


## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [x] Write documentation
- [x] Create issues for future work
- [x] Test on your machine
- [x] Test on the robot
- [x] Put the PR on our Project board

