### PR TITLE
Remove z movement from odometry

### DIFF
--- a/bitbots_odometry/package.xml
+++ b/bitbots_odometry/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_odometry</name>
-  <version>1.0.9</version>
+  <version>1.0.10</version>
   <description>The bitbots_odometry package</description>
 
   <maintainer email="5guelden@informatik.uni-hamburg.de">Jasper Güldenstein</maintainer>

--- a/bitbots_odometry/src/motion_odometry.cpp
+++ b/bitbots_odometry/src/motion_odometry.cpp
@@ -60,7 +60,7 @@ MotionOdometry::MotionOdometry() {
           current_to_next_support.setOrigin({
                                                 current_to_next_support.getOrigin().x(),
                                                 current_to_next_support.getOrigin().y(),
-                                                current_to_next_support.getOrigin().z()});
+                                                0});
           tf2::Quaternion q;
           q.setRPY(0, 0, tf2::getYaw(current_to_next_support.getRotation()));
           current_to_next_support.setRotation(q);


### PR DESCRIPTION
## Proposed changes
This PR removes the z movement from the odometry which was introduced in #158 and resulted in a drift in the z axis. It closes #162.

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [ ] ~Write documentation~
- [ ] ~Create issues for future work~
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

