### PR TITLE
Fix/dynamic kick rate

### DIFF
--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_node.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_node.h
@@ -68,7 +68,7 @@ class KickNode {
    * Do main loop in which KickEngine::update() gets called repeatedly.
    * The ActionServer's state is taken into account meaning that a cancelled goal no longer gets processed.
    */
-  void loopEngine();
+  void loopEngine(ros::Rate loop_rate);
 
   /**
    * Retrieve current feet_positions in base_link frame

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_node.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_node.h
@@ -90,9 +90,7 @@ class KickNode {
    */
   double getTimeDelta();
 
-
-
-    /**
+  /**
    * Publish goals to ROS
    */
   void publishGoals(const bitbots_splines::JointGoals &goals);

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_node.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_node.h
@@ -58,6 +58,7 @@ class KickNode {
   Visualizer visualizer_;
   KickIK ik_;
   int engine_rate_;
+  double last_ros_update_time_;
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener listener_;
   robot_model_loader::RobotModelLoader robot_model_loader_;
@@ -85,6 +86,13 @@ class KickNode {
   void publishSupportFoot(bool is_left_kick);
 
   /**
+   * Helper method to achieve correctly sampled rate
+   */
+  double getTimeDelta();
+
+
+
+    /**
    * Publish goals to ROS
    */
   void publishGoals(const bitbots_splines::JointGoals &goals);

--- a/bitbots_dynamic_kick/package.xml
+++ b/bitbots_dynamic_kick/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_dynamic_kick</name>
-  <version>0.1.7</version>
+  <version>0.1.8</version>
   <description>
 	  The bitbots_dynamic_kick package implements a kick which is not based on keyframe animations.
 	  Instead it aims to dynamically reach it's movement goal while keeping the robot stable and controllable.

--- a/bitbots_dynamic_kick/src/kick_node.cpp
+++ b/bitbots_dynamic_kick/src/kick_node.cpp
@@ -121,7 +121,8 @@ void KickNode::executeCb(const bitbots_msgs::KickGoalConstPtr &goal) {
   visualizer_.displayWindupPoint(engine_.getWindupPoint(), (engine_.isLeftKick()) ? "r_sole" : "l_sole");
   visualizer_.displayFlyingSplines(engine_.getFlyingSplines(), (engine_.isLeftKick()) ? "r_sole" : "l_sole");
   visualizer_.displayTrunkSplines(engine_.getTrunkSplines());
-  loopEngine();
+  ros::Rate loop_rate(engine_rate_);
+  loopEngine(loop_rate);
 
   /* Figure out the reason why loopEngine() returned and act accordingly */
   if (server_.isPreemptRequested()) {
@@ -183,7 +184,7 @@ std::pair<geometry_msgs::Pose, geometry_msgs::Pose> KickNode::getFootPoses() {
         return dt;
     }
 
-void KickNode::loopEngine() {
+void KickNode::loopEngine(ros::Rate loop_rate) {
   /* Do the loop as long as nothing cancels it */
       double dt;
   while (server_.isActive() && !server_.isPreemptRequested()) {
@@ -208,7 +209,6 @@ void KickNode::loopEngine() {
 
     /* Let ROS do some important work of its own and sleep afterwards */
     ros::spinOnce();
-    ros::Rate loop_rate(engine_rate_);
     loop_rate.sleep();
   }
 }

--- a/bitbots_dynamic_kick/src/kick_node.cpp
+++ b/bitbots_dynamic_kick/src/kick_node.cpp
@@ -162,34 +162,34 @@ std::pair<geometry_msgs::Pose, geometry_msgs::Pose> KickNode::getFootPoses() {
   return std::pair(r_foot_transformed.pose, l_foot_transformed.pose);
 }
 
-    double KickNode::getTimeDelta() {
-        // compute actual time delta that happened
-        double dt;
-        double current_ros_time = ros::Time::now().toSec();
+double KickNode::getTimeDelta() {
+  // compute actual time delta that happened
+  double dt;
+  double current_ros_time = ros::Time::now().toSec();
 
-        // first call needs to be handled specially
-        if (last_ros_update_time_==0){
-            last_ros_update_time_ = current_ros_time;
-            return 0.001;
-        }
+  // first call needs to be handled specially
+  if (last_ros_update_time_ == 0){
+    last_ros_update_time_ = current_ros_time;
+    return 0.001;
+  }
 
-        dt = current_ros_time - last_ros_update_time_;
-        // this can happen due to floating point precision
-        if (dt == 0) {
-            ROS_WARN("dt was 0");
-            dt = 0.001;
-        }
-        last_ros_update_time_ = current_ros_time;
+  dt = current_ros_time - last_ros_update_time_;
+  // this can happen due to floating point precision
+  if (dt == 0) {
+    ROS_WARN("dt was 0");
+    dt = 0.001;
+  }
+  last_ros_update_time_ = current_ros_time;
 
-        return dt;
-    }
+  return dt;
+}
 
 void KickNode::loopEngine(ros::Rate loop_rate) {
   /* Do the loop as long as nothing cancels it */
-      double dt;
+  double dt;
   while (server_.isActive() && !server_.isPreemptRequested()) {
-      dt = getTimeDelta();
-      KickPositions positions = engine_.update(dt);
+    dt = getTimeDelta();
+    KickPositions positions = engine_.update(dt);
     // TODO: should positions be an std::optional? how are errors represented?
     KickPositions stabilized_positions = stabilizer_.stabilize(positions, ros::Duration(dt));
     bitbots_splines::JointGoals motor_goals = ik_.calculate(stabilized_positions);

--- a/bitbots_dynamic_kick/src/kick_node.cpp
+++ b/bitbots_dynamic_kick/src/kick_node.cpp
@@ -176,7 +176,7 @@ double KickNode::getTimeDelta() {
   dt = current_ros_time - last_ros_update_time_;
   // this can happen due to floating point precision
   if (dt == 0) {
-    ROS_WARN("dt was 0");
+    ROS_WARN("dynamic kick: dt was 0");
     dt = 0.001;
   }
   last_ros_update_time_ = current_ros_time;


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes and why they are necessary. -->
This fixes an issue where the loop rate would be calculated incorrectly, similar to the issue fixed in the recent Dynup commit 2866274c841637181a60bd40d18771adb4564666.

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

