### PR TITLE
Fix falling and fallen

### DIFF
--- a/bitbots_hcm/package.xml
+++ b/bitbots_hcm/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_hcm</name>
-  <version>2.2.3</version>
+  <version>2.2.4</version>
   <description>The bitbots_hcm package provides a low-level behavior which controls the current state of the robot.
   It will perform falling and standing-up handling by its own. It will also decide which other nodes can write motor
   goal positions.</description>

--- a/bitbots_hcm/src/bitbots_hcm/fall_checker.py
+++ b/bitbots_hcm/src/bitbots_hcm/fall_checker.py
@@ -76,7 +76,13 @@ class FallChecker(BaseEstimator):
     def calc_fall_quantification(self, falling_threshold_orientation, falling_threshold_gyro, current_axis_euler,
                                  current_axis__gyro):
         # check if you are moving forward or away from the perpendicular position, by comparing the signs.
-        if numpy.sign(current_axis_euler) == numpy.sign(current_axis__gyro):
+        moving_more_upright = numpy.sign(current_axis_euler) != numpy.sign(current_axis__gyro)
+
+        # Check if the orientation is over the point of no return threshold
+        over_point_of_no_return = abs(current_axis_euler) > falling_threshold_orientation
+
+        # Calculate quantification if we are moving away from our upright position or if we are over the point of no return
+        if not moving_more_upright or over_point_of_no_return:
             # calculatiung the orentation skalar for the threshold
             skalar = max((falling_threshold_orientation - abs(current_axis_euler)) / falling_threshold_orientation, 0)
             # checking if the rotation velocity is lower than the the threshold

--- a/bitbots_hcm/src/bitbots_hcm/fall_checker.py
+++ b/bitbots_hcm/src/bitbots_hcm/fall_checker.py
@@ -5,7 +5,6 @@ import numpy
 from sensor_msgs.msg import Imu
 import rospy
 
-# todo hip pitch offset
 from sklearn.base import BaseEstimator
 from sklearn.metrics import accuracy_score
 

--- a/bitbots_hcm/src/bitbots_hcm/fall_checker.py
+++ b/bitbots_hcm/src/bitbots_hcm/fall_checker.py
@@ -107,26 +107,26 @@ class FallChecker(BaseEstimator):
             y.append(prediction)
         return y
 
-    def check_fallen(self, smooth_accel, not_much_smoothed_gyro):
+    def check_fallen(self, quaternion, not_much_smoothed_gyro):
         """Check if the robot has fallen and is lying on the floor. Returns animation to play, if necessary."""
-        # Checks if the robot is still moving.
-        if any(abs(n) >= 0.1 for n in not_much_smoothed_gyro):
-            return None
+
+        # Convert quaternion to fused angles
+        fused_roll, fused_pitch, _ = self.fused_from_quat(quaternion)
 
         # Decides which side is facing downwards.
-        if smooth_accel[0] < -7:
+        if fused_pitch > math.radians(75):
             rospy.loginfo("FALLEN TO THE FRONT")
             return self.FRONT
 
-        if smooth_accel[0] > 7:
+        if fused_pitch < math.radians(-75):
             rospy.loginfo("FALLEN TO THE BACK")
             return self.BACK
 
-        if smooth_accel[1] > 7:
+        if fused_roll > math.radians(75):
             rospy.loginfo("FALLEN TO THE RIGHT")
             return self.RIGHT
 
-        if smooth_accel[1] < -7:
+        if fused_roll < math.radians(-75):
             rospy.loginfo("FALLEN TO THE LEFT")
             return self.LEFT
 

--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/actions/play_animation.py
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/actions/play_animation.py
@@ -180,7 +180,6 @@ class PlayAnimationDynup(AbstractActionElement):
             return
 
         if self.animation_finished():
-            self.blackboard.hacky_sequence_dynup_running = False
             # we are finished playing this animation
             return self.pop()
 

--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/actions/wait.py
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/actions/wait.py
@@ -34,6 +34,6 @@ class Wait(AbstractActionElement):
 
 class WaitNoReevaluate(Wait):
     def perform(self, reevaluate=False):
-        self.dsd.set_do_not_reevaluate()
+        self._dsd.set_do_not_reevaluate()
         if self.time < rospy.get_time():
             self.pop()

--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/decisions/decisions.py
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/decisions/decisions.py
@@ -94,7 +94,7 @@ class CheckMotors(AbstractDecisionElement):
 
         if self.blackboard.simulation_active:
             # Some simulators will give exact same joint messages which look like errors, so ignore this case
-            if self.last_msg:
+            if self.blackboard.last_motor_update_time != rospy.Time.from_sec(0):
                 return "OKAY"
             else:
                 return "MOTORS_NOT_STARTED"

--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/decisions/decisions.py
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/decisions/decisions.py
@@ -346,11 +346,10 @@ class Fallen(AbstractDecisionElement):
 
     def perform(self, reevaluate=False):
         # check if the robot is currently laying on the ground
-        fallen_side = self.blackboard.fall_checker.check_fallen(self.blackboard.smooth_accel, self.blackboard.gyro)
+        fallen_side = self.blackboard.fall_checker.check_fallen(self.blackboard.quaternion, self.blackboard.gyro)
         if self.blackboard.is_stand_up_active and fallen_side is not None:
             self.blackboard.current_state = STATE_FALLEN
             # TODO
-            self.blackboard.hacky_sequence_dynup_running = True
             # we play a stand up animation
             if fallen_side == self.blackboard.fall_checker.FRONT:
                 return "FALLEN_FRONT"
@@ -365,7 +364,7 @@ class Fallen(AbstractDecisionElement):
             return "NOT_FALLEN"
 
     def get_reevaluate(self):
-        return not self.blackboard.hacky_sequence_dynup_running
+        return True 
 
 
 class ExternalAnimation(AbstractDecisionElement):

--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/hcm_blackboard.py
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/hcm_blackboard.py
@@ -120,7 +120,6 @@ class HcmBlackboard():
         self.fall_checker = FallChecker()
         self.is_stand_up_active = rospy.get_param("hcm/stand_up_active", True)
         self.falling_detection_active = rospy.get_param("hcm/falling_active", True)
-        self.hacky_sequence_dynup_running = False
 
         # kicking
         self.last_kick_feedback = None  # type: rospy.Time


### PR DESCRIPTION
## Proposed changes
- Dont interpret quaternion as euler angles in the `falling`
- Use fused angles instead of euler
- Use orientation instead of gyro to determine the `falling` direction if a fall is detected (less issues with bouncing robots)
- Use fused angles to determine the `fallen` detection
- Remove `hacky_sequence_dynup_running` which blocks falling very oftern in sim (maybe also on robot)

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [x] Test on your machine
- [x] Test on the robot
- [x] Put the PR on our Project board

