### PR TITLE
hcm: do not play walkready animation on idle

### DIFF
--- a/bitbots_hcm/package.xml
+++ b/bitbots_hcm/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_hcm</name>
-  <version>2.2.3</version>
+  <version>2.3.0</version>
   <description>The bitbots_hcm package provides a low-level behavior which controls the current state of the robot.
   It will perform falling and standing-up handling by its own. It will also decide which other nodes can write motor
   goal positions.</description>

--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/actions/stay.py
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/actions/stay.py
@@ -1,7 +1,7 @@
 import rospy
 import humanoid_league_msgs.msg
 from dynamic_stack_decider.abstract_action_element import AbstractActionElement
-from bitbots_hcm.hcm_dsd.hcm_blackboard import HcmBlackboard, STATE_HCM_OFF, STATE_PENALTY
+from bitbots_hcm.hcm_dsd.hcm_blackboard import HcmBlackboard, STATE_HCM_OFF, STATE_PENALTY, STATE_CONTROLLABLE
 
 
 class AbstractStay(AbstractActionElement):
@@ -20,7 +20,8 @@ class AbstractStay(AbstractActionElement):
 
 
 class StayControlable(AbstractStay):
-    pass
+    def perform(self):
+        self.blackboard.current_state = STATE_CONTROLLABLE
 
 
 class StayWalking(AbstractStay):

--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/decisions/decisions.py
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/decisions/decisions.py
@@ -24,8 +24,28 @@ class StartHCM(AbstractDecisionElement):
                 return "SHUTDOWN_REQUESTED"
         else:
             if not reevaluate:
+                if not self.is_walkready():
+                    return "NOT_WALKREADY"
                 self.blackboard.current_state = STATE_STARTUP
             return "RUNNING"
+
+    def is_walkready(self):
+        """
+        We check if any joint is has an offset from the walkready pose which is higher than a threshold
+        """
+        if self.blackboard.current_joint_state is None:
+            return False
+        i = 0
+        for joint_name in self.blackboard.current_joint_state.name:
+            if joint_name == "HeadPan" or joint_name == "HeadTilt":
+                # we dont care about the head position
+                i += 1
+                continue
+            if abs(math.degrees(self.blackboard.current_joint_state.position[i]) -
+                   self.blackboard.walkready_pose_dict[joint_name]) > self.blackboard.walkready_pose_threshold:
+                return False
+            i += 1
+        return True
 
     def get_reevaluate(self):
         return True
@@ -319,6 +339,8 @@ class Sitting(AbstractDecisionElement):
     def perform(self, reevaluate=False):
         # simple check is looking at knee joint positions
         # todo can be done more sophisticated
+        if self.blackboard.current_joint_state is None:
+            return "NO"
         left_knee = 0
         right_knee = 0
         i = 0
@@ -401,42 +423,6 @@ class Walking(AbstractDecisionElement):
                 return "STAY_WALKING"
         else:
             return "NOT_WALKING"
-
-    def get_reevaluate(self):
-        return True
-
-
-class Controlable(AbstractDecisionElement):
-    """
-    Decides if the robot is currently controlable
-    """
-
-    def perform(self, reevaluate=False):
-        # check if the robot is in a walkready pose
-        if not self.is_walkready():
-            self.blackboard.current_state = STATE_ANIMATION_RUNNING
-            return "NOT_WALKREADY"
-        else:
-            self.blackboard.current_state = STATE_CONTROLLABLE
-            return "WALKREADY"
-
-    def is_walkready(self):
-        """
-        We check if any joint is has an offset from the walkready pose which is higher than a threshold
-        """
-        if self.blackboard.current_joint_state is None:
-            return False
-        i = 0
-        for joint_name in self.blackboard.current_joint_state.name:
-            if joint_name == "HeadPan" or joint_name == "HeadTilt":
-                # we dont care about the head position
-                i += 1
-                continue
-            if abs(math.degrees(self.blackboard.current_joint_state.position[i]) -
-                   self.blackboard.walkready_pose_dict[joint_name]) > self.blackboard.walkready_pose_threshold:
-                return False
-            i += 1
-        return True
 
     def get_reevaluate(self):
         return True

--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/hcm.dsd
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/hcm.dsd
@@ -5,6 +5,7 @@ $PickedUp
 
 -->HCM
 $StartHCM
+    NOT_WALKREADY --> @PlayAnimationWalkready
     SHUTDOWN_REQUESTED --> #ShutDownProcedure
     SHUTDOWN_WHILE_HARDWARE_PROBLEM --> @StayShutDown
     RUNNING --> $Stop
@@ -15,7 +16,7 @@ $StartHCM
                 MOTORS_NOT_STARTED --> @WaitForMotorStartup
                 PROBLEM --> @WaitForMotors
                 TURN_OFF --> @PlayAnimationSitDown, @TurnMotorsOff, @StayMotorsOff
-                TURN_ON --> @TurnMotorsOn
+                TURN_ON --> @TurnMotorsOn, @PlayAnimationWalkready
                 OKAY --> $CheckIMU
                     IMU_NOT_STARTED --> @WaitForIMUStartup
                     PROBLEM --> @WaitForIMU
@@ -43,6 +44,4 @@ $StartHCM
                                                 STAY_WALKING --> @StayWalking
                                                 NOT_WALKING --> $Kicking
                                                     KICKING --> @StayKicking
-                                                    NOT_KICKING --> $Controlable
-                                                        NOT_WALKREADY --> @PlayAnimationWalkready
-                                                        WALKREADY --> @StayControlable
+                                                    NOT_KICKING --> @StayControlable


### PR DESCRIPTION
## Proposed changes
This removes the last element of the hcm decision tree where walkready is always executed. At startup and after turning the motors back on, walkready is still executed.

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board