### PR TITLE
hcm: fix NoneType problem when joint states are not set on startup

### DIFF
--- a/bitbots_hcm/package.xml
+++ b/bitbots_hcm/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>bitbots_hcm</name>
-  <version>2.2.3</version>
+  <version>2.2.4</version>
   <description>The bitbots_hcm package provides a low-level behavior which controls the current state of the robot.
   It will perform falling and standing-up handling by its own. It will also decide which other nodes can write motor
   goal positions.</description>

--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/decisions/decisions.py
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/decisions/decisions.py
@@ -317,6 +317,8 @@ class Sitting(AbstractDecisionElement):
     """
 
     def perform(self, reevaluate=False):
+        if self.blackboard.current_joint_state is None:
+            return "NO"
         # simple check is looking at knee joint positions
         # todo can be done more sophisticated
         left_knee = 0


### PR DESCRIPTION
## Proposed changes
This adds a simple check to the `Sitting` decision so that the hcm does not die when `current_joint_state` is not set yet. This can only happen in visualization when the motor helper script is loaded after the hcm. A similar check already exists in the `is_walkready` method.

## Necessary checks
- [x] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] ~Test on the robot~
- [x] Put the PR on our Project board

