### PR TITLE
kick: add sim parameter to launch file

### DIFF
--- a/bitbots_dynamic_kick/launch/test.launch
+++ b/bitbots_dynamic_kick/launch/test.launch
@@ -1,6 +1,14 @@
+<?xml version="1.0"?>
 <launch>
-  <include file="$(find bitbots_ros_control)/launch/ros_control.launch" />
-  <include file="$(find bitbots_bringup)/launch/load_robot_description.launch" />
+  <arg name="sim" default="false"/>
+
+  <include file="$(find bitbots_bringup)/launch/load_robot_description.launch" >
+    <arg name="sim" value="$(arg sim)"/>
+  </include>
+
+  <group unless="$(arg sim)">
+    <include file="$(find bitbots_ros_control)/launch/ros_control.launch" />
+  </group>
 
   <arg if="$(optenv IS_ROBOT false)" name="taskset" default="taskset -c 3"/>
   <arg unless="$(optenv IS_ROBOT false)" name="taskset" default=""/>


### PR DESCRIPTION
## Proposed changes
This adds a `sim` parameter to the `test.launch` launch file of the dynamic kick.

## Necessary checks
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

