### PR TITLE
Improve kick time

### DIFF
--- a/bitbots_dynamic_kick/config/kick_config.yaml
+++ b/bitbots_dynamic_kick/config/kick_config.yaml
@@ -11,13 +11,13 @@ trunk_pitch: 0
 trunk_yaw: 0
 
 # Timings
-move_trunk_time: 1.5
-raise_foot_time: 0.7
-move_to_ball_time: 1
+move_trunk_time: 0.5
+raise_foot_time: 0.3
+move_to_ball_time: 0.1
 kick_time: 0.1
 move_back_time: 0.2
-lower_foot_time: 0.8
-move_trunk_back_time: 0.3
+lower_foot_time: 0.1
+move_trunk_back_time: 0.2
 
 # Decisions
 choose_foot_corridor_width: 0.4
@@ -25,8 +25,9 @@ choose_foot_corridor_width: 0.4
 ### Stabilizer ###
 use_center_of_pressure: false
 stabilizing_point_x: 0.0
-stabilizing_point_y: 0.021
+stabilizing_point_y: 0.015
 
+# these values are used only if use_center_of_pressure is true
 pid_x/p: 0.2
 pid_x/i: 0
 pid_x/d: 0


### PR DESCRIPTION
## Proposed changes
This pull requests improves the velocity of the kick from almost five seconds to 1.5 seconds. It is stable in webots, when testing please keep in mind to set the robot to walkready before executing the kick.

## Necessary checks
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

