### PR TITLE
Add a python wrapper for the kick

### DIFF
--- a/bitbots_dynamic_kick/CMakeLists.txt
+++ b/bitbots_dynamic_kick/CMakeLists.txt
@@ -22,6 +22,16 @@ find_package(catkin REQUIRED COMPONENTS
         message_runtime
 )
 
+catkin_python_setup()
+
+find_package(PythonLibs)
+if(PYTHONLIBS_VERSION_STRING VERSION_LESS "3.8")
+    find_package(Boost REQUIRED COMPONENTS python3)
+else()
+    find_package(Boost REQUIRED COMPONENTS python)
+endif()
+find_package (PythonLibs COMPONENTS Interpreter Development)
+
 generate_dynamic_reconfigure_options(
         cfg/bitbots_dynamic_kick_params.cfg
 )
@@ -46,6 +56,8 @@ enable_bitbots_docs()
 include_directories(
         include
         ${catkin_INCLUDE_DIRS}
+        ${Boost_INCLUDE_DIRS}
+        ${PYTHON_INCLUDE_DIRS}
 )
 
 set(SOURCES
@@ -60,3 +72,15 @@ add_executable(KickNode ${SOURCES})
 add_dependencies(KickNode ${PROJECT_NAME}_gencfg ${PROJECT_NAME}_generate_messages)
 
 target_link_libraries(KickNode ${catkin_LIBRARIES})
+
+# create the kick python wrapper
+add_library(py_dynamic_kick SHARED src/kick_pywrapper.cpp ${SOURCES})
+add_dependencies(py_dynamic_kick ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS} ${PROJECT_NAME}_gencfg)
+
+# link
+target_link_libraries(py_dynamic_kick ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${CODE_LIBRARIES})
+
+set_target_properties(py_dynamic_kick PROPERTIES
+        PREFIX ""
+        LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}
+)

--- a/bitbots_dynamic_kick/CMakeLists.txt
+++ b/bitbots_dynamic_kick/CMakeLists.txt
@@ -20,17 +20,17 @@ find_package(catkin REQUIRED COMPONENTS
         control_toolbox
         message_generation
         message_runtime
+        rotconv
 )
 
 catkin_python_setup()
 
-find_package(PythonLibs)
+find_package(PythonLibs COMPONENTS Interpreter Development)
 if(PYTHONLIBS_VERSION_STRING VERSION_LESS "3.8")
     find_package(Boost REQUIRED COMPONENTS python3)
 else()
     find_package(Boost REQUIRED COMPONENTS python)
 endif()
-find_package (PythonLibs COMPONENTS Interpreter Development)
 
 generate_dynamic_reconfigure_options(
         cfg/bitbots_dynamic_kick_params.cfg
@@ -68,18 +68,13 @@ set(SOURCES
         src/kick_ik.cpp)
 
 add_executable(KickNode ${SOURCES})
-
 add_dependencies(KickNode ${PROJECT_NAME}_gencfg ${PROJECT_NAME}_generate_messages)
-
 target_link_libraries(KickNode ${catkin_LIBRARIES})
 
 # create the kick python wrapper
 add_library(py_dynamic_kick SHARED src/kick_pywrapper.cpp ${SOURCES})
 add_dependencies(py_dynamic_kick ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS} ${PROJECT_NAME}_gencfg)
-
-# link
-target_link_libraries(py_dynamic_kick ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${CODE_LIBRARIES})
-
+target_link_libraries(py_dynamic_kick ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 set_target_properties(py_dynamic_kick PROPERTIES
         PREFIX ""
         LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_engine.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_engine.h
@@ -117,11 +117,6 @@ class KickEngine : public bitbots_splines::AbstractEngine<KickGoals, KickPositio
    */
   KickPhase getPhase() const;
 
-  /**
-   * Get the current time of the engine (0 is start of kick) in seconds
-   */
-  double getTime() const;
-
   Eigen::Vector3d getWindupPoint();
 
   /**

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_engine.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_engine.h
@@ -1,13 +1,16 @@
 #ifndef BITBOTS_DYNAMIC_KICK_INCLUDE_BITBOTS_DYNAMIC_KICK_KICK_ENGINE_H_
 #define BITBOTS_DYNAMIC_KICK_INCLUDE_BITBOTS_DYNAMIC_KICK_KICK_ENGINE_H_
 
+#include <cmath>
 #include <optional>
-#include <std_msgs/Header.h>
+#include <Eigen/Geometry>
+#include <rot_conv/rot_conv.h>
 #include <bitbots_splines/pose_spline.h>
 #include <bitbots_splines/position_spline.h>
 #include <bitbots_splines/abstract_engine.h>
 #include <bitbots_msgs/KickGoal.h>
 #include <bitbots_msgs/KickFeedback.h>
+#include <tf2_eigen/tf2_eigen.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2/convert.h>
 #include <tf2/utils.h>
@@ -123,33 +126,37 @@ class KickEngine : public bitbots_splines::AbstractEngine<KickGoals, KickPositio
 
   KickPhase getPhase() const;
 
-  tf2::Vector3 getWindupPoint();
+  Eigen::Vector3d getWindupPoint();
+
+  /**
+   * Set a pointer to the current state of the robot, updated from joint states
+   */
+  void setRobotState(robot_state::RobotStatePtr current_state);
 
  private:
   double time_;
-  tf2::Vector3 ball_position_;
-  tf2::Quaternion kick_direction_;
-  float kick_speed_;
+  Eigen::Vector3d ball_position_;
+  Eigen::Quaterniond kick_direction_;
+  double kick_speed_;
   bool is_left_kick_;
   bitbots_splines::PoseSpline flying_foot_spline_, trunk_spline_;
   KickParams params_;
   PhaseTimings phase_timings_;
-  tf2::Vector3 windup_point_;
-
-  tf2_ros::Buffer tf_buffer_;
-  tf2_ros::TransformListener listener_;
+  Eigen::Vector3d windup_point_;
+  robot_state::RobotStatePtr current_state_;
 
   /**
    *  Calculate splines for a complete kick whereby is_left_kick_ should already be set correctly
    *
-   *  @param flying_foot_pose Current pose of the foot which is supposed to be the flying/kicking one
+   *  @param flying_foot_pose Current pose of the flying foot relative to the support foot
+   *  @param trunk_pose Current pose of the trunk relative to the support foot
    */
-  void calcSplines(const geometry_msgs::Pose &flying_foot_pose, const geometry_msgs::Transform &trunk_pose);
+  void calcSplines(const Eigen::Isometry3d &flying_foot_pose, const Eigen::Isometry3d &trunk_pose);
 
   /**
    *  Calculate the point from which to perform the final kicking movement
    */
-  tf2::Vector3 calcKickWindupPoint();
+  Eigen::Vector3d calcKickWindupPoint();
 
   /**
    * Choose with which foot the kick should be performed
@@ -158,18 +165,19 @@ class KickEngine : public bitbots_splines::AbstractEngine<KickGoals, KickPositio
    * If it is, the foot on that side will be chosen as the kicking foot.
    * If not, a more fine grained angle based criterion is used.     *
    *
-   * @param header Definition of frame and time in which the goals were published
    * @param ball_position Position where the ball is currently located
    * @param kick_direction Direction into which the ball should be kicked
    * @return Whether the resulting kick should be performed with the left foot
    *
    * @throws tf2::TransformException when ball_position and kick_direction cannot be converted into base_footprint frame
    */
-  bool calcIsLeftFootKicking(const std_msgs::Header &header,
-                             const geometry_msgs::Vector3 &ball_position,
-                             const geometry_msgs::Quaternion &kick_direction);
+  bool calcIsLeftFootKicking(const Eigen::Vector3d &ball_position,
+                             const Eigen::Quaterniond &kick_direction);
 
-  geometry_msgs::Transform getTrunkPose();
+  /**
+   * Get the current position of the trunk relative to the support foot
+   */
+  Eigen::Isometry3d getTrunkPose();
 
   /**
    * Calculate the yaw of the kicking foot, so that it is turned
@@ -180,18 +188,18 @@ class KickEngine : public bitbots_splines::AbstractEngine<KickGoals, KickPositio
   /**
    * Transform then goal into our support_foots frame
    * @param support_foot_frame Name of the support foots frame, meaning where to transform to
-   * @param header Frame and time in which the goals were published
+   * @param trunk_to_base_footprint Pose of the base_footprint relative to the trunk
    * @param ball_position Position of the ball
    * @param kick_direction Direction in which to kick the ball
    * @return pair of (transformed_pose, transformed_direction)
    *
    * @throws tf2::TransformException when goal cannot be transformed into support_foot_frame
    */
-  std::pair<geometry_msgs::Point, geometry_msgs::Quaternion> transformGoal(
+  std::pair<Eigen::Vector3d, Eigen::Quaterniond> transformGoal(
       const std::string &support_foot_frame,
-      const std_msgs::Header &header,
-      const geometry_msgs::Vector3 &ball_position,
-      const geometry_msgs::Quaternion &kick_direction);
+      const Eigen::Isometry3d &trunk_to_base_footprint,
+      const Eigen::Vector3d &ball_position,
+      const Eigen::Quaterniond &kick_direction);
 };
 }
 

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_engine.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_engine.h
@@ -44,18 +44,6 @@ struct KickParams {
   double choose_foot_corridor_width;
 };
 
-enum KickPhase {
-  INITIAL,
-  MOVE_TRUNK,
-  RAISE_FOOT,
-  WINDUP,
-  KICK,
-  MOVE_BACK,
-  LOWER_FOOT,
-  MOVE_TRUNK_BACK,
-  DONE
-};
-
 /**
  * An instance of this class describes after which time a KickPhase is done
  */
@@ -124,7 +112,15 @@ class KickEngine : public bitbots_splines::AbstractEngine<KickGoals, KickPositio
 
   void setParams(KickParams params);
 
+  /**
+   * Get the current phase of the engine
+   */
   KickPhase getPhase() const;
+
+  /**
+   * Get the current time of the engine (0 is start of kick) in seconds
+   */
+  double getTime() const;
 
   Eigen::Vector3d getWindupPoint();
 

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_ik.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_ik.h
@@ -1,12 +1,11 @@
 #ifndef BITBOTS_DYNAMIC_KICK_INCLUDE_BITBOTS_DYNAMIC_KICK_KICK_IK_H_
 #define BITBOTS_DYNAMIC_KICK_INCLUDE_BITBOTS_DYNAMIC_KICK_KICK_IK_H_
 
+#include <Eigen/Geometry>
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include <moveit/planning_scene/planning_scene.h>
 #include <bitbots_splines/abstract_ik.h>
 #include <bitbots_dynamic_kick/kick_utils.h>
-#include <tf2/convert.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 namespace bitbots_dynamic_kick {
 

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_node.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_node.h
@@ -35,7 +35,7 @@ typedef actionlib::SimpleActionServer<bitbots_msgs::KickAction> ActionServer;
  */
 class KickNode {
  public:
-  KickNode();
+  explicit KickNode(const std::string &ns = std::string());
 
   /** Callback for dynamic reconfigure */
   void reconfigureCallback(bitbots_dynamic_kick::DynamicKickConfig &config, uint32_t level);
@@ -45,6 +45,26 @@ class KickNode {
    * @param goal New goal to process
    */
   void executeCb(const bitbots_msgs::KickGoalConstPtr &goal);
+
+  /**
+   * This wrapper is used in the python wrapper for a single step of the kick
+   * @param dt the time difference since the last call of this method
+   * @return the JointCommand representing the next step or an empty JointCommand if the kick is done
+   */
+  bitbots_msgs::JointCommand stepWrapper(double dt);
+
+  /**
+   * Get the current progress of the kick, from 0 to 1
+   */
+  double getProgress();
+
+  /**
+   * Initialize the node
+   * @param goal The goal of the kick
+   * @param error_string when the return value is false, this will contain details about the error
+   * @return whether the setup was successful
+   */
+  bool init(const bitbots_msgs::KickGoal &goal, std::string& error_string);
 
  private:
   ros::NodeHandle node_handle_;
@@ -72,6 +92,12 @@ class KickNode {
   void loopEngine(ros::Rate loop_rate);
 
   /**
+   * Execute one step of engine-stabilize-ik
+   * @return the motor goals
+   */
+  bitbots_splines::JointGoals kickStep(double dt);
+
+  /**
    * Retrieve current feet_positions in base_link frame
    *
    * @return The pair of (right foot, left foot) poses if transformation was successfull
@@ -92,9 +118,9 @@ class KickNode {
   double getTimeDelta();
 
   /**
-   * Publish goals to ROS
+   * Get JointCommand message for JointGoals
    */
-  void publishGoals(const bitbots_splines::JointGoals &goals);
+  bitbots_msgs::JointCommand getJointCommand(const bitbots_splines::JointGoals &goals);
   void copLCallback(const geometry_msgs::PointStamped &cop);
   void copRCallback(const geometry_msgs::PointStamped &cop);
 };

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_node.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_node.h
@@ -69,6 +69,10 @@ class KickNode {
    */
   bool init(const bitbots_msgs::KickGoal &goal_msg, std::string &error_string, Eigen::Isometry3d &trunk_to_base_footprint);
 
+  /**
+   * Set the current joint state of the robot
+   */
+  void jointStateCallback(const sensor_msgs::JointState &joint_states);
  private:
   ros::NodeHandle node_handle_;
   ros::Publisher joint_goal_publisher_;
@@ -119,7 +123,6 @@ class KickNode {
   bitbots_msgs::JointCommand getJointCommand(const bitbots_splines::JointGoals &goals);
   void copLCallback(const geometry_msgs::PointStamped &cop);
   void copRCallback(const geometry_msgs::PointStamped &cop);
-  void jointStateCallback(const sensor_msgs::JointState &joint_states);
 };
 }
 

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_pywrapper.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_pywrapper.h
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <map>
 #include <Python.h>
+#include <Eigen/Geometry>
 #include <boost/python.hpp>
 #include <ros/ros.h>
 #include <sensor_msgs/JointState.h>
@@ -14,7 +15,7 @@ class PyKickWrapper {
  public:
   explicit PyKickWrapper(std::string ns);
   moveit::py_bindings_tools::ByteString step(double dt, const std::string &joint_state_str);
-  bool init(const std::string &goal);
+  bool set_goal(const std::string &goal_str, const std::string &trunk_to_base_footprint_str);
   double get_progress();
   void set_params(boost::python::object params);
 

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_pywrapper.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_pywrapper.h
@@ -15,6 +15,7 @@ class PyKickWrapper {
   moveit::py_bindings_tools::ByteString step(double dt);
   bool init(const std::string &goal);
   double get_progress();
+  void set_params(const boost::python::object params);
 
  private:
   std::shared_ptr<bitbots_dynamic_kick::KickNode> kick_node_;

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_pywrapper.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_pywrapper.h
@@ -6,16 +6,17 @@
 #include <Python.h>
 #include <boost/python.hpp>
 #include <ros/ros.h>
+#include <sensor_msgs/JointState.h>
 #include <moveit/py_bindings_tools/serialize_msg.h>
 #include <bitbots_dynamic_kick/kick_node.h>
 
 class PyKickWrapper {
  public:
-  PyKickWrapper(const std::string ns);
-  moveit::py_bindings_tools::ByteString step(double dt);
+  explicit PyKickWrapper(std::string ns);
+  moveit::py_bindings_tools::ByteString step(double dt, const std::string &joint_state_str);
   bool init(const std::string &goal);
   double get_progress();
-  void set_params(const boost::python::object params);
+  void set_params(boost::python::object params);
 
  private:
   std::shared_ptr<bitbots_dynamic_kick::KickNode> kick_node_;

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_pywrapper.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_pywrapper.h
@@ -1,0 +1,23 @@
+#ifndef BITBOTS_DYNAMIC_KICK_INCLUDE_BITBOTS_DYNAMIC_KICK_KICK_PYWRAPPER_H_
+#define BITBOTS_DYNAMIC_KICK_INCLUDE_BITBOTS_DYNAMIC_KICK_KICK_PYWRAPPER_H_
+
+#include <iostream>
+#include <map>
+#include <Python.h>
+#include <boost/python.hpp>
+#include <ros/ros.h>
+#include <moveit/py_bindings_tools/serialize_msg.h>
+#include <bitbots_dynamic_kick/kick_node.h>
+
+class PyKickWrapper {
+ public:
+  PyKickWrapper(const std::string ns);
+  moveit::py_bindings_tools::ByteString step(double dt);
+  bool init(const std::string &goal);
+  double get_progress();
+
+ private:
+  std::shared_ptr<bitbots_dynamic_kick::KickNode> kick_node_;
+};
+
+#endif //BITBOTS_DYNAMIC_KICK_INCLUDE_BITBOTS_DYNAMIC_KICK_KICK_PYWRAPPER_H_

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_utils.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_utils.h
@@ -1,30 +1,23 @@
 #ifndef BITBOTS_DYNAMIC_KICK_INCLUDE_BITBOTS_DYNAMIC_KICK_KICK_UTILS_H_
 #define BITBOTS_DYNAMIC_KICK_INCLUDE_BITBOTS_DYNAMIC_KICK_KICK_UTILS_H_
 
-#include <geometry_msgs/Point.h>
-#include <geometry_msgs/Pose.h>
-#include <geometry_msgs/PoseStamped.h>
-#include <geometry_msgs/Quaternion.h>
-#include <geometry_msgs/Vector3.h>
-#include <tf2/LinearMath/Transform.h>
+#include <Eigen/Geometry>
 
 namespace bitbots_dynamic_kick {
 
 struct KickPositions {
   bool is_left_kick = true;
-  tf2::Transform trunk_pose;
-  tf2::Transform flying_foot_pose;
+  Eigen::Isometry3d trunk_pose;
+  Eigen::Isometry3d flying_foot_pose;
   bool cop_support_point = false;
   double engine_time;
 };
 
 struct KickGoals {
-  std_msgs::Header header;
-  geometry_msgs::Vector3 ball_position;
-  geometry_msgs::Quaternion kick_direction;
+  Eigen::Vector3d ball_position;
+  Eigen::Quaterniond kick_direction;
   double kick_speed = 0;
-  geometry_msgs::Pose r_foot_pose;
-  geometry_msgs::Pose l_foot_pose;
+  Eigen::Isometry3d trunk_to_base_footprint;
 };
 
 }

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_utils.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_utils.h
@@ -2,6 +2,7 @@
 #define BITBOTS_DYNAMIC_KICK_INCLUDE_BITBOTS_DYNAMIC_KICK_KICK_UTILS_H_
 
 #include <Eigen/Geometry>
+#include <bitbots_dynamic_kick/KickDebug.h>
 
 namespace bitbots_dynamic_kick {
 
@@ -18,6 +19,18 @@ struct KickGoals {
   Eigen::Quaterniond kick_direction;
   double kick_speed = 0;
   Eigen::Isometry3d trunk_to_base_footprint;
+};
+
+enum KickPhase {
+  INITIAL = KickDebug::INITIAL,
+  MOVE_TRUNK = KickDebug::MOVE_TRUNK,
+  RAISE_FOOT = KickDebug::RAISE_FOOT,
+  WINDUP = KickDebug::WINDUP,
+  KICK = KickDebug::KICK,
+  MOVE_BACK = KickDebug::MOVE_BACK,
+  LOWER_FOOT = KickDebug::LOWER_FOOT,
+  MOVE_TRUNK_BACK = KickDebug::MOVE_TRUNK_BACK,
+  DONE = KickDebug::DONE
 };
 
 }

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/visualizer.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/visualizer.h
@@ -39,7 +39,7 @@ class Visualizer : bitbots_splines::AbstractVisualizer {
 
   void setParams(VisualizationParams params);
 
-  void displayReceivedGoal(const bitbots_msgs::KickGoalConstPtr &goal);
+  void displayReceivedGoal(const bitbots_msgs::KickGoal &goal);
 
   void displayFlyingSplines(bitbots_splines::PoseSpline splines, const std::string &support_foot_frame);
 

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/visualizer.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/visualizer.h
@@ -43,11 +43,15 @@ class Visualizer : bitbots_splines::AbstractVisualizer {
 
   void displayFlyingSplines(bitbots_splines::PoseSpline splines, const std::string &support_foot_frame);
 
-  void displayTrunkSplines(bitbots_splines::PoseSpline splines);
+  void displayTrunkSplines(bitbots_splines::PoseSpline splines, const std::string &support_foot_frame);
 
   void displayWindupPoint(const Eigen::Vector3d &kick_windup_point, const std::string &support_foot_frame);
 
-  void publishGoals(const KickPositions &positions, const KickPositions &stabilized_positions, const robot_state::RobotStatePtr& robot_state);
+  void publishGoals(const KickPositions &positions,
+                    const KickPositions &stabilized_positions,
+                    const robot_state::RobotStatePtr &robot_state,
+                    double engine_time,
+                    KickPhase engine_phase);
 
  private:
   ros::NodeHandle node_handle_;

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/visualizer.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/visualizer.h
@@ -50,7 +50,6 @@ class Visualizer : bitbots_splines::AbstractVisualizer {
   void publishGoals(const KickPositions &positions,
                     const KickPositions &stabilized_positions,
                     const robot_state::RobotStatePtr &robot_state,
-                    double engine_time,
                     KickPhase engine_phase);
 
  private:

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/visualizer.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/visualizer.h
@@ -45,7 +45,7 @@ class Visualizer : bitbots_splines::AbstractVisualizer {
 
   void displayTrunkSplines(bitbots_splines::PoseSpline splines);
 
-  void displayWindupPoint(const tf2::Vector3 &kick_windup_point, const std::string &support_foot_frame);
+  void displayWindupPoint(const Eigen::Vector3d &kick_windup_point, const std::string &support_foot_frame);
 
   void publishGoals(const KickPositions &positions, const KickPositions &stabilized_positions, const robot_state::RobotStatePtr& robot_state);
 

--- a/bitbots_dynamic_kick/msg/KickDebug.msg
+++ b/bitbots_dynamic_kick/msg/KickDebug.msg
@@ -1,6 +1,17 @@
 std_msgs/Header header
 
+uint8 INITIAL=0
+uint8 MOVE_TRUNK=1
+uint8 RAISE_FOOT=2
+uint8 WINDUP=3
+uint8 KICK=4
+uint8 MOVE_BACK=5
+uint8 LOWER_FOOT=6
+uint8 MOVE_TRUNK_BACK=7
+uint8 DONE=8
+
 float64 engine_time
+uint8 engine_phase
 
 # some poses useful for debugging, for example in plotjuggler
 # everything is relative to the support foot

--- a/bitbots_dynamic_kick/msg/KickDebug.msg
+++ b/bitbots_dynamic_kick/msg/KickDebug.msg
@@ -10,12 +10,12 @@ float64 engine_time
 # - poses computed by running FK on the IK results
 # - the translational difference between the IK input and IK output (i.e. stabilized_goal and ik_result)
 
-geometry_msgs/Transform trunk_pose_goal
-geometry_msgs/Transform trunk_pose_stabilized_goal
-geometry_msgs/Transform trunk_pose_ik_result
-geometry_msgs/Vector3 trunk_position_ik_offset
+geometry_msgs/Pose trunk_pose_goal
+geometry_msgs/Pose trunk_pose_stabilized_goal
+geometry_msgs/Pose trunk_pose_ik_result
+geometry_msgs/Point trunk_position_ik_offset
 
-geometry_msgs/Transform flying_foot_pose_goal
-geometry_msgs/Transform flying_foot_pose_stabilized_goal
-geometry_msgs/Transform flying_foot_pose_ik_result
-geometry_msgs/Vector3 flying_foot_position_ik_offset
+geometry_msgs/Pose flying_foot_pose_goal
+geometry_msgs/Pose flying_foot_pose_stabilized_goal
+geometry_msgs/Pose flying_foot_pose_ik_result
+geometry_msgs/Point flying_foot_position_ik_offset

--- a/bitbots_dynamic_kick/scripts/dummy_client.py
+++ b/bitbots_dynamic_kick/scripts/dummy_client.py
@@ -76,10 +76,10 @@ if __name__ == "__main__":
     goal.header.stamp = rospy.Time.now()
     goal.header.frame_id = "base_footprint"
     goal.ball_position.x = 0.2
-    goal.ball_position.y = -0.09
+    goal.ball_position.y = float(sys.argv[1])
     goal.ball_position.z = 0
 
-    goal.kick_direction = Quaternion(*quaternion_from_euler(0, 0, 0))
+    goal.kick_direction = Quaternion(*quaternion_from_euler(0, 0, float(sys.argv[2])))
 
     goal.kick_speed = 1
 

--- a/bitbots_dynamic_kick/setup.py
+++ b/bitbots_dynamic_kick/setup.py
@@ -1,0 +1,9 @@
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+d = generate_distutils_setup(
+    packages=['bitbots_dynamic_kick'],
+    package_dir={'': 'src'},
+)
+
+setup(**d)

--- a/bitbots_dynamic_kick/src/bitbots_dynamic_kick/__init__.py
+++ b/bitbots_dynamic_kick/src/bitbots_dynamic_kick/__init__.py
@@ -1,0 +1,1 @@
+from bitbots_dynamic_kick.py_kick_wrapper import PyKick

--- a/bitbots_dynamic_kick/src/bitbots_dynamic_kick/py_kick_wrapper.py
+++ b/bitbots_dynamic_kick/src/bitbots_dynamic_kick/py_kick_wrapper.py
@@ -1,0 +1,56 @@
+from io import BytesIO
+
+from moveit_ros_planning_interface._moveit_roscpp_initializer import roscpp_init, roscpp_shutdown
+from bitbots_dynamic_kick.py_dynamic_kick import PyKickWrapper
+from bitbots_msgs.msg import JointCommand, KickGoal
+
+
+def _to_cpp(msg):
+    """Return a serialized string from a ROS message
+
+    Parameters
+    ----------
+    - msg: a ROS message instance.
+    """
+    buf = BytesIO()
+    msg.serialize(buf)
+    value = buf.getvalue()
+    return value
+
+
+def _from_cpp(str_msg, cls):
+    """Return a ROS message from a serialized string
+
+    Parameters
+    ----------
+    - str_msg: str, serialized message
+    - cls: ROS message class, e.g. sensor_msgs.msg.LaserScan.
+    """
+    msg = cls()
+    result = msg.deserialize(str_msg)
+    return result
+
+
+class PyKick():
+    def __init__(self, namespace=""):
+        roscpp_init('py_kick', [])
+        # make namespace end with a /
+        if namespace != "" and namespace[-1] != '/':
+            namespace = namespace + "/"
+        self.py_kick_wrapper = PyKickWrapper(namespace)
+
+    def __del__(self):
+        roscpp_shutdown()
+
+    def init(self, msg: KickGoal):
+        return self.py_kick_wrapper.init(_to_cpp(msg))
+
+    def step(self, dt: float):
+        if dt == 0.0:
+            # preventing weird spline interpolation errors on edge case
+            dt = 0.001
+        step = self.py_kick_wrapper.step(dt)
+        return _from_cpp(step, JointCommand)
+
+    def get_progress(self):
+        return self.py_kick_wrapper.get_progress()

--- a/bitbots_dynamic_kick/src/bitbots_dynamic_kick/py_kick_wrapper.py
+++ b/bitbots_dynamic_kick/src/bitbots_dynamic_kick/py_kick_wrapper.py
@@ -1,11 +1,12 @@
 from io import BytesIO
 
 from moveit_ros_planning_interface._moveit_roscpp_initializer import roscpp_init, roscpp_shutdown
+from sensor_msgs.msg import JointState
 from bitbots_dynamic_kick.py_dynamic_kick import PyKickWrapper
 from bitbots_msgs.msg import JointCommand, KickGoal
 
 
-def _to_cpp(msg):
+def to_cpp(msg):
     """Return a serialized string from a ROS message
 
     Parameters
@@ -18,7 +19,7 @@ def _to_cpp(msg):
     return value
 
 
-def _from_cpp(str_msg, cls):
+def from_cpp(str_msg, cls):
     """Return a ROS message from a serialized string
 
     Parameters
@@ -43,14 +44,14 @@ class PyKick():
         roscpp_shutdown()
 
     def init(self, msg: KickGoal):
-        return self.py_kick_wrapper.init(_to_cpp(msg))
+        return self.py_kick_wrapper.init(to_cpp(msg))
 
-    def step(self, dt: float):
+    def step(self, dt: float, joint_state: JointState):
         if dt == 0.0:
             # preventing weird spline interpolation errors on edge case
             dt = 0.001
-        step = self.py_kick_wrapper.step(dt)
-        return _from_cpp(step, JointCommand)
+        step = self.py_kick_wrapper.step(dt, to_cpp(joint_state))
+        return from_cpp(step, JointCommand)
 
     def get_progress(self):
         return self.py_kick_wrapper.get_progress()

--- a/bitbots_dynamic_kick/src/bitbots_dynamic_kick/py_kick_wrapper.py
+++ b/bitbots_dynamic_kick/src/bitbots_dynamic_kick/py_kick_wrapper.py
@@ -54,3 +54,6 @@ class PyKick():
 
     def get_progress(self):
         return self.py_kick_wrapper.get_progress()
+
+    def set_params(self, params_dict):
+        self.py_kick_wrapper.set_params(params_dict)

--- a/bitbots_dynamic_kick/src/kick_engine.cpp
+++ b/bitbots_dynamic_kick/src/kick_engine.cpp
@@ -320,10 +320,6 @@ KickPhase KickEngine::getPhase() const {
     return KickPhase::DONE;
 }
 
-double KickEngine::getTime() const {
-  return time_;
-}
-
 void KickEngine::setParams(KickParams params) {
   params_ = params;
 }

--- a/bitbots_dynamic_kick/src/kick_engine.cpp
+++ b/bitbots_dynamic_kick/src/kick_engine.cpp
@@ -320,6 +320,10 @@ KickPhase KickEngine::getPhase() const {
     return KickPhase::DONE;
 }
 
+double KickEngine::getTime() const {
+  return time_;
+}
+
 void KickEngine::setParams(KickParams params) {
   params_ = params;
 }

--- a/bitbots_dynamic_kick/src/kick_node.cpp
+++ b/bitbots_dynamic_kick/src/kick_node.cpp
@@ -212,7 +212,7 @@ bitbots_splines::JointGoals KickNode::kickStep(double dt) {
   for (int i = 0; i < motor_goals.first.size(); ++i) {
     goal_state_->setJointPositions(motor_goals.first[i], &motor_goals.second[i]);
   }
-  visualizer_.publishGoals(positions, stabilized_positions, goal_state_, engine_.getTime(), engine_.getPhase());
+  visualizer_.publishGoals(positions, stabilized_positions, goal_state_, engine_.getPhase());
   publishSupportFoot(engine_.isLeftKick());
 
   return motor_goals;

--- a/bitbots_dynamic_kick/src/kick_node.cpp
+++ b/bitbots_dynamic_kick/src/kick_node.cpp
@@ -111,7 +111,7 @@ bool KickNode::init(const bitbots_msgs::KickGoal &goal_msg,
   visualizer_.displayReceivedGoal(goal_msg);
   visualizer_.displayWindupPoint(engine_.getWindupPoint(), (engine_.isLeftKick()) ? "r_sole" : "l_sole");
   visualizer_.displayFlyingSplines(engine_.getFlyingSplines(), (engine_.isLeftKick()) ? "r_sole" : "l_sole");
-  visualizer_.displayTrunkSplines(engine_.getTrunkSplines());
+  visualizer_.displayTrunkSplines(engine_.getTrunkSplines(), (engine_.isLeftKick() ? "r_sole" : "l_sole"));
 
   return true;
 }
@@ -122,7 +122,7 @@ void KickNode::executeCb(const bitbots_msgs::KickGoalConstPtr &goal) {
 
   /* get transform to base_footprint */
   geometry_msgs::TransformStamped
-      tf_trunk_to_base_footprint = tf_buffer_.lookupTransform("base_footprint", "base_link", ros::Time(0));
+      tf_trunk_to_base_footprint = tf_buffer_.lookupTransform("base_link", "base_footprint", ros::Time(0));
   Eigen::Isometry3d trunk_to_base_footprint = tf2::transformToEigen(tf_trunk_to_base_footprint);
 
   /* pass everything to the init function */
@@ -212,7 +212,7 @@ bitbots_splines::JointGoals KickNode::kickStep(double dt) {
   for (int i = 0; i < motor_goals.first.size(); ++i) {
     goal_state_->setJointPositions(motor_goals.first[i], &motor_goals.second[i]);
   }
-  visualizer_.publishGoals(positions, stabilized_positions, goal_state_);
+  visualizer_.publishGoals(positions, stabilized_positions, goal_state_, engine_.getTime(), engine_.getPhase());
   publishSupportFoot(engine_.isLeftKick());
 
   return motor_goals;

--- a/bitbots_dynamic_kick/src/kick_node.cpp
+++ b/bitbots_dynamic_kick/src/kick_node.cpp
@@ -1,13 +1,10 @@
 #include "bitbots_dynamic_kick/kick_node.h"
 
-#include <memory>
-
 namespace bitbots_dynamic_kick {
 
 KickNode::KickNode(const std::string &ns) :
     server_(node_handle_, "dynamic_kick", boost::bind(&KickNode::executeCb, this, _1), false),
     listener_(tf_buffer_),
-    engine_(),
     visualizer_("/debug/dynamic_kick"),
     robot_model_loader_("/robot_description", false) {
 
@@ -21,13 +18,17 @@ KickNode::KickNode(const std::string &ns) :
   stabilizer_.setRobotModel(kinematic_model);
   ik_.init(kinematic_model);
 
-  /* this debug variable represents the current state of the robot */
+  /* this debug variable represents the goal state of the robot, i.e. what the ik goals are */
+  goal_state_.reset(new robot_state::RobotState(kinematic_model));
+  /* this variable represents the current state of the robot, retrieved from joint states */
   current_state_.reset(new robot_state::RobotState(kinematic_model));
+  engine_.setRobotState(current_state_);
 
   joint_goal_publisher_ = node_handle_.advertise<bitbots_msgs::JointCommand>("kick_motor_goals", 1);
   support_foot_publisher_ = node_handle_.advertise<std_msgs::Char>("dynamic_kick_support_state", 1, /* latch = */ true);
   cop_l_subscriber_ = node_handle_.subscribe("cop_l", 1, &KickNode::copLCallback, this);
   cop_r_subscriber_ = node_handle_.subscribe("cop_r", 1, &KickNode::copRCallback, this);
+  joint_state_subscriber_ = node_handle_.subscribe("joint_states", 1, &KickNode::jointStateCallback, this);
   server_.start();
 }
 
@@ -43,6 +44,12 @@ void KickNode::copRCallback(const geometry_msgs::PointStamped &cop) {
     ROS_ERROR_STREAM("cop_r not in r_sole frame! Stabilizing will not work.");
   }
   stabilizer_.cop_right = cop.point;
+}
+
+void KickNode::jointStateCallback(const sensor_msgs::JointState &joint_states) {
+  for (int i = 0; i < joint_states.name.size(); ++i) {
+    current_state_->setJointPositions(joint_states.name[i], &joint_states.position[i]);
+  }
 }
 
 void KickNode::reconfigureCallback(bitbots_dynamic_kick::DynamicKickConfig &config, uint32_t /* level */) {
@@ -75,57 +82,60 @@ void KickNode::reconfigureCallback(bitbots_dynamic_kick::DynamicKickConfig &conf
   visualizer_.setParams(viz_params);
 }
 
-bool KickNode::init(const bitbots_msgs::KickGoal &goal, std::string &error_string) {
-  engine_.reset();
+bool KickNode::init(const bitbots_msgs::KickGoal &goal_msg,
+                    std::string &error_string,
+                    Eigen::Isometry3d &trunk_to_base_footprint) {
+  /* currently, the ball must always be in the base_footprint frame */
+  if (goal_msg.header.frame_id != "base_footprint") {
+    ROS_ERROR_STREAM("Goal should be in base_footprint frame");
+    error_string = "Goal should be in base_footprint frame";
+    return false;
+  }
+
+  /* reset the current state */
   last_ros_update_time_ = 0;
   was_support_foot_published_ = false;
-  std::pair<geometry_msgs::Pose, geometry_msgs::Pose> foot_poses;
-  try {
-    foot_poses = getFootPoses();
-  } catch (tf2::TransformException &e) {
-    ROS_ERROR("Could not process goal because current feet positions could not be transformed into base_link");
-    error_string = "Transformation of feet into base_link not possible";
-    return false;
-  }
-  visualizer_.displayReceivedGoal(goal);
-
-  /* Set engines goal and start calculating */
-  KickGoals goals;
-  goals.ball_position = goal.ball_position;
-  goals.header = goal.header;
-  goals.kick_direction = goal.kick_direction;
-  goals.kick_speed = goal.kick_speed;
-  goals.r_foot_pose = foot_poses.first;
-  goals.l_foot_pose = foot_poses.second;
-
-  try {
-    engine_.setGoals(goals);
-  } catch (tf2::TransformException &e) {
-    ROS_ERROR_STREAM(e.what());
-    ROS_ERROR_STREAM("Could not transform goal to needed tf frames: " << e.what());
-    error_string = "Could not transform goal to needed tf frames";
-    return false;
-  }
-
+  engine_.reset();
   stabilizer_.reset();
   ik_.reset();
+
+  /* Set engines goal_msg and start calculating */
+  KickGoals goals;
+  tf2::convert(goal_msg.ball_position, goals.ball_position);
+  tf2::convert(goal_msg.kick_direction, goals.kick_direction);
+  goals.kick_speed = goal_msg.kick_speed;
+  goals.trunk_to_base_footprint = trunk_to_base_footprint;
+  engine_.setGoals(goals);
+
+  /* visualization */
+  visualizer_.displayReceivedGoal(goal_msg);
   visualizer_.displayWindupPoint(engine_.getWindupPoint(), (engine_.isLeftKick()) ? "r_sole" : "l_sole");
   visualizer_.displayFlyingSplines(engine_.getFlyingSplines(), (engine_.isLeftKick()) ? "r_sole" : "l_sole");
   visualizer_.displayTrunkSplines(engine_.getTrunkSplines());
+
   return true;
 }
 
 void KickNode::executeCb(const bitbots_msgs::KickGoalConstPtr &goal) {
   // TODO: maybe switch to goal callback to be able to reject goals properly
   ROS_INFO("Accepted new goal");
+
+  /* get transform to base_footprint */
+  geometry_msgs::TransformStamped
+      tf_trunk_to_base_footprint = tf_buffer_.lookupTransform("base_footprint", "base_link", ros::Time(0));
+  Eigen::Isometry3d trunk_to_base_footprint = tf2::transformToEigen(tf_trunk_to_base_footprint);
+
+  /* pass everything to the init function */
   std::string error_string;
-  bool success = init(*goal, error_string);
+  bool success = init(*goal, error_string, trunk_to_base_footprint);
+  /* there was an error, abort the kick */
   if (!success) {
     bitbots_msgs::KickResult result;
     result.result = bitbots_msgs::KickResult::REJECTED;
     server_.setAborted(result, error_string);
   }
 
+  /* everything is set up, start calculating now until the kick is finished or an error occurs */
   ros::Rate loop_rate(engine_rate_);
   loopEngine(loop_rate);
 
@@ -145,41 +155,19 @@ void KickNode::executeCb(const bitbots_msgs::KickGoalConstPtr &goal) {
   }
 }
 
-std::pair<geometry_msgs::Pose, geometry_msgs::Pose> KickNode::getFootPoses() {
-  ros::Time time = ros::Time::now();
-
-  /* Construct zero-positions for both feet in their respective local frames */
-  geometry_msgs::PoseStamped r_foot_origin, l_foot_origin;
-  r_foot_origin.header.frame_id = "r_sole";
-  r_foot_origin.pose.orientation.w = 1;
-  r_foot_origin.header.stamp = time;
-
-  l_foot_origin.header.frame_id = "l_sole";
-  l_foot_origin.pose.orientation.w = 1;
-  l_foot_origin.header.stamp = time;
-
-  /* Transform both feet poses into the other foot's frame */
-  geometry_msgs::PoseStamped r_foot_transformed, l_foot_transformed;
-  tf_buffer_.transform(r_foot_origin, r_foot_transformed, "l_sole",
-                       ros::Duration(0.2));
-  tf_buffer_.transform(l_foot_origin, l_foot_transformed, "r_sole", ros::Duration(0.2));
-
-  return std::pair(r_foot_transformed.pose, l_foot_transformed.pose);
-}
-
 double KickNode::getTimeDelta() {
   // compute actual time delta that happened
   double dt;
   double current_ros_time = ros::Time::now().toSec();
 
   // first call needs to be handled specially
-  if (last_ros_update_time_ == 0){
+  if (last_ros_update_time_ == 0) {
     last_ros_update_time_ = current_ros_time;
     return 0.001;
   }
 
   dt = current_ros_time - last_ros_update_time_;
-  // this can happen due to floating point precision
+  // this can happen due to floating point precision or in simulation
   if (dt == 0) {
     ROS_WARN("dynamic kick: dt was 0");
     dt = 0.001;
@@ -222,9 +210,9 @@ bitbots_splines::JointGoals KickNode::kickStep(double dt) {
 
   /* visualization of the values calculated above */
   for (int i = 0; i < motor_goals.first.size(); ++i) {
-    current_state_->setJointPositions(motor_goals.first[i], &motor_goals.second[i]);
+    goal_state_->setJointPositions(motor_goals.first[i], &motor_goals.second[i]);
   }
-  visualizer_.publishGoals(positions, stabilized_positions, current_state_);
+  visualizer_.publishGoals(positions, stabilized_positions, goal_state_);
   publishSupportFoot(engine_.isLeftKick());
 
   return motor_goals;
@@ -257,9 +245,9 @@ bitbots_msgs::JointCommand KickNode::getJointCommand(const bitbots_splines::Join
 
 void KickNode::publishSupportFoot(bool is_left_kick) {
   std_msgs::Char msg;
-  msg.data = !is_left_kick ? 'l' : 'r';
+  msg.data = is_left_kick ? 'r' : 'l';
   // only publish one time per kick
-  if(!was_support_foot_published_){
+  if (!was_support_foot_published_) {
     support_foot_publisher_.publish(msg);
     was_support_foot_published_ = true;
   }

--- a/bitbots_dynamic_kick/src/kick_pywrapper.cpp
+++ b/bitbots_dynamic_kick/src/kick_pywrapper.cpp
@@ -42,6 +42,50 @@ moveit::py_bindings_tools::ByteString PyKickWrapper::step(double dt) {
   return moveit::py_bindings_tools::serializeMsg(result);
 }
 
+void PyKickWrapper::set_params(const boost::python::object params) {
+  using namespace boost::python;
+
+  extract<dict> cppdict_ext(params);
+  if (!cppdict_ext.check()) {
+    throw std::runtime_error("type error: not a python dict");
+  }
+
+  dict cppdict = cppdict_ext();
+  list keylist = cppdict.keys();
+
+  bitbots_dynamic_kick::DynamicKickConfig conf;
+
+  int len = boost::python::len(keylist);
+
+  for (int i = 0; i < len; ++i) {
+    std::string keystr = extract<std::string>(str(keylist[i]));
+    std::string valstr = extract<std::string>(str(cppdict[keylist[i]]));
+    if (keystr == "engine_rate") { conf.engine_rate = std::stoi(valstr); }
+    else if (keystr == "foot_rise") { conf.foot_rise = std::stof(valstr); }
+    else if (keystr == "foot_distance") { conf.foot_distance = std::stof(valstr); }
+    else if (keystr == "kick_windup_distance") { conf.kick_windup_distance = std::stof(valstr); }
+    else if (keystr == "trunk_height") { conf.trunk_height = std::stof(valstr); }
+    else if (keystr == "trunk_roll") { conf.trunk_roll = std::stof(valstr); }
+    else if (keystr == "trunk_pitch") { conf.trunk_pitch = std::stof(valstr); }
+    else if (keystr == "trunk_yaw") { conf.trunk_yaw = std::stof(valstr); }
+    else if (keystr == "move_trunk_time") { conf.move_trunk_time = std::stof(valstr); }
+    else if (keystr == "raise_foot_time") { conf.raise_foot_time = std::stof(valstr); }
+    else if (keystr == "move_to_ball_time") { conf.move_to_ball_time = std::stof(valstr); }
+    else if (keystr == "kick_time") { conf.kick_time = std::stof(valstr); }
+    else if (keystr == "move_back_time") { conf.move_back_time = std::stof(valstr); }
+    else if (keystr == "lower_foot_time") { conf.lower_foot_time = std::stof(valstr); }
+    else if (keystr == "move_trunk_back_time") { conf.move_trunk_back_time = std::stof(valstr); }
+    else if (keystr == "choose_foot_corridor_width") { conf.choose_foot_corridor_width = std::stof(valstr); }
+    else if (keystr == "use_center_of_pressure") { conf.use_center_of_pressure = valstr == "True"; }
+    else if (keystr == "stabilizing_point_x") { conf.stabilizing_point_x = std::stof(valstr); }
+    else if (keystr == "stabilizing_point_y") { conf.stabilizing_point_y = std::stof(valstr); }
+    else if (keystr == "spline_smoothness") { conf.spline_smoothness = std::stoi(valstr); }
+    else { std::cerr << keystr << " not known. WILL BE IGNORED." << std::endl; }
+  }
+
+  kick_node_->reconfigureCallback(conf, 0xff);
+}
+
 bool PyKickWrapper::init(const std::string &goal_str) {
   auto goal = from_python<bitbots_msgs::KickGoal>(goal_str);
   std::string error_string;
@@ -52,13 +96,13 @@ double PyKickWrapper::get_progress() {
   return kick_node_->getProgress();
 }
 
-BOOST_PYTHON_MODULE(py_dynamic_kick)
-{
+BOOST_PYTHON_MODULE (py_dynamic_kick) {
   using namespace boost::python;
   using namespace bitbots_dynamic_kick;
 
   class_<PyKickWrapper>("PyKickWrapper", init<std::string>())
       .def("init", &PyKickWrapper::init)
       .def("step", &PyKickWrapper::step)
-      .def("get_progress", &PyKickWrapper::get_progress);
+      .def("get_progress", &PyKickWrapper::get_progress)
+      .def("set_params", &PyKickWrapper::set_params);
 }

--- a/bitbots_dynamic_kick/src/kick_pywrapper.cpp
+++ b/bitbots_dynamic_kick/src/kick_pywrapper.cpp
@@ -89,7 +89,8 @@ void PyKickWrapper::set_params(const boost::python::object params) {
 bool PyKickWrapper::init(const std::string &goal_str) {
   auto goal = from_python<bitbots_msgs::KickGoal>(goal_str);
   std::string error_string;
-  return kick_node_->init(goal, error_string);
+  Eigen::Isometry3d trunk_to_base_footprint;
+  return kick_node_->init(goal, error_string, trunk_to_base_footprint);
 }
 
 double PyKickWrapper::get_progress() {

--- a/bitbots_dynamic_kick/src/kick_pywrapper.cpp
+++ b/bitbots_dynamic_kick/src/kick_pywrapper.cpp
@@ -1,0 +1,64 @@
+#include <bitbots_dynamic_kick/kick_pywrapper.h>
+
+/**
+ * Read a ROS message from a serialized string.
+ */
+template<typename M>
+M from_python(const std::string &str_msg) {
+  size_t serial_size = str_msg.size();
+  boost::shared_array<uint8_t> buffer(new uint8_t[serial_size]);
+  for (size_t i = 0; i < serial_size; ++i) {
+    buffer[i] = str_msg[i];
+  }
+  ros::serialization::IStream stream(buffer.get(), serial_size);
+  M msg;
+  ros::serialization::Serializer<M>::read(stream, msg);
+  return msg;
+}
+
+/**
+ * Write a ROS message into a serialized string.
+ */
+template<typename M>
+std::string to_python(const M &msg) {
+  size_t serial_size = ros::serialization::serializationLength(msg);
+  boost::shared_array<uint8_t> buffer(new uint8_t[serial_size]);
+  ros::serialization::OStream stream(buffer.get(), serial_size);
+  ros::serialization::serialize(stream, msg);
+  std::string str_msg;
+  str_msg.reserve(serial_size);
+  for (size_t i = 0; i < serial_size; ++i) {
+    str_msg.push_back(buffer[i]);
+  }
+  return str_msg;
+}
+
+PyKickWrapper::PyKickWrapper(const std::string ns) {
+  kick_node_ = std::make_shared<bitbots_dynamic_kick::KickNode>(ns);
+}
+
+moveit::py_bindings_tools::ByteString PyKickWrapper::step(double dt) {
+  std::string result = to_python<bitbots_msgs::JointCommand>(kick_node_->stepWrapper(dt));
+  return moveit::py_bindings_tools::serializeMsg(result);
+}
+
+bool PyKickWrapper::init(const std::string &goal_str) {
+  auto goal = from_python<bitbots_msgs::KickGoal>(goal_str);
+  std::string error_string;
+  return kick_node_->init(goal, error_string);
+}
+
+double PyKickWrapper::get_progress() {
+  return kick_node_->getProgress();
+}
+
+BOOST_PYTHON_MODULE(py_dynamic_kick)
+{
+  using namespace boost::python;
+  using namespace bitbots_dynamic_kick;
+
+  class_<PyKickWrapper>("PyKickWrapper", init<std::string>())
+      .def("init", &PyKickWrapper::init)
+      .def("step", &PyKickWrapper::step)
+      .def("get_progress", &PyKickWrapper::get_progress);
+}

--- a/bitbots_dynamic_kick/src/kick_pywrapper.cpp
+++ b/bitbots_dynamic_kick/src/kick_pywrapper.cpp
@@ -37,7 +37,9 @@ PyKickWrapper::PyKickWrapper(const std::string ns) {
   kick_node_ = std::make_shared<bitbots_dynamic_kick::KickNode>(ns);
 }
 
-moveit::py_bindings_tools::ByteString PyKickWrapper::step(double dt) {
+moveit::py_bindings_tools::ByteString PyKickWrapper::step(double dt, const std::string &joint_state_str) {
+  sensor_msgs::JointState joint_state = from_python<sensor_msgs::JointState>(joint_state_str);
+  kick_node_->jointStateCallback(joint_state);
   std::string result = to_python<bitbots_msgs::JointCommand>(kick_node_->stepWrapper(dt));
   return moveit::py_bindings_tools::serializeMsg(result);
 }

--- a/bitbots_dynamic_kick/src/stabilizer.cpp
+++ b/bitbots_dynamic_kick/src/stabilizer.cpp
@@ -29,13 +29,14 @@ KickPositions Stabilizer::stabilize(const KickPositions &positions, const ros::D
       cop_x = cop_left.x;
       cop_y = cop_left.y;
     }
-    cop_x_error = cop_x - positions.trunk_pose.getOrigin().getX();
-    cop_y_error = cop_y - positions.trunk_pose.getOrigin().getY();
+    cop_x_error = cop_x - positions.trunk_pose.translation().x();
+    cop_y_error = cop_y - positions.trunk_pose.translation().y();
 
     double x_correction = pid_x_.computeCommand(cop_x_error, dt);
     double y_correction = pid_y_.computeCommand(cop_y_error, dt);
 
-    stabilized_positions.trunk_pose.getOrigin() += {x_correction, y_correction, 0};
+    stabilized_positions.trunk_pose.translation().x() += x_correction;
+    stabilized_positions.trunk_pose.translation().y() += y_correction;
   }
   return stabilized_positions;
 }

--- a/bitbots_dynamic_kick/src/visualizer.cpp
+++ b/bitbots_dynamic_kick/src/visualizer.cpp
@@ -39,11 +39,12 @@ void Visualizer::displayFlyingSplines(bitbots_splines::PoseSpline splines,
   foot_spline_publisher_.publish(path);
 }
 
-void Visualizer::displayTrunkSplines(bitbots_splines::PoseSpline splines) {
+void Visualizer::displayTrunkSplines(bitbots_splines::PoseSpline splines,
+                                     const std::string &support_foot_frame) {
   if (trunk_spline_publisher_.getNumSubscribers() == 0)
     return;
 
-  visualization_msgs::MarkerArray path = getPath(splines, "base_link", params_.spline_smoothness);
+  visualization_msgs::MarkerArray path = getPath(splines, support_foot_frame, params_.spline_smoothness);
   path.markers[0].color.g = 1;
 
   trunk_spline_publisher_.publish(path);
@@ -84,7 +85,9 @@ void Visualizer::displayWindupPoint(const Eigen::Vector3d &kick_windup_point, co
 
 void Visualizer::publishGoals(const KickPositions &positions,
                               const KickPositions &stabilized_positions,
-                              const robot_state::RobotStatePtr &robot_state) {
+                              const robot_state::RobotStatePtr &robot_state,
+                              double engine_time,
+                              KickPhase engine_phase) {
   /* only calculate the debug information if someone is subscribing */
   if (debug_publisher_.getNumSubscribers() == 0) {
     return;
@@ -113,6 +116,8 @@ void Visualizer::publishGoals(const KickPositions &positions,
   KickDebug msg;
   msg.header.stamp = ros::Time::now();
   msg.header.frame_id = support_foot_frame;
+  msg.engine_phase = engine_phase;
+  msg.engine_time = engine_time;
   msg.engine_time = positions.engine_time;
   msg.trunk_pose_goal = tf2::toMsg(positions.trunk_pose);
   msg.trunk_pose_stabilized_goal = tf2::toMsg(stabilized_positions.trunk_pose);

--- a/bitbots_dynamic_kick/src/visualizer.cpp
+++ b/bitbots_dynamic_kick/src/visualizer.cpp
@@ -49,19 +49,19 @@ void Visualizer::displayTrunkSplines(bitbots_splines::PoseSpline splines) {
   trunk_spline_publisher_.publish(path);
 }
 
-void Visualizer::displayReceivedGoal(const bitbots_msgs::KickGoalConstPtr &goal) {
+void Visualizer::displayReceivedGoal(const bitbots_msgs::KickGoal &goal) {
   if (goal_publisher_.getNumSubscribers() == 0)
     return;
 
   visualization_msgs::Marker
-      marker = getMarker({goal->ball_position.x, goal->ball_position.y, goal->ball_position.z}, goal->header.frame_id);
+      marker = getMarker({goal.ball_position.x, goal.ball_position.y, goal.ball_position.z}, goal.header.frame_id);
 
   marker.ns = marker_ns_;
   marker.id = MarkerIDs::RECEIVED_GOAL;
   marker.type = visualization_msgs::Marker::ARROW;
-  marker.header.stamp = goal->header.stamp;
-  marker.pose.orientation = goal->kick_direction;
-  marker.scale.x = 0.08 + (goal->kick_speed / 3);
+  marker.header.stamp = goal.header.stamp;
+  marker.pose.orientation = goal.kick_direction;
+  marker.scale.x = 0.08 + (goal.kick_speed / 3);
   marker.color.r = 1;
 
   goal_publisher_.publish(marker);

--- a/bitbots_dynamic_kick/src/visualizer.cpp
+++ b/bitbots_dynamic_kick/src/visualizer.cpp
@@ -86,7 +86,6 @@ void Visualizer::displayWindupPoint(const Eigen::Vector3d &kick_windup_point, co
 void Visualizer::publishGoals(const KickPositions &positions,
                               const KickPositions &stabilized_positions,
                               const robot_state::RobotStatePtr &robot_state,
-                              double engine_time,
                               KickPhase engine_phase) {
   /* only calculate the debug information if someone is subscribing */
   if (debug_publisher_.getNumSubscribers() == 0) {
@@ -117,7 +116,6 @@ void Visualizer::publishGoals(const KickPositions &positions,
   msg.header.stamp = ros::Time::now();
   msg.header.frame_id = support_foot_frame;
   msg.engine_phase = engine_phase;
-  msg.engine_time = engine_time;
   msg.engine_time = positions.engine_time;
   msg.trunk_pose_goal = tf2::toMsg(positions.trunk_pose);
   msg.trunk_pose_stabilized_goal = tf2::toMsg(stabilized_positions.trunk_pose);


### PR DESCRIPTION
## Proposed changes
Similar to the existing one for the walking, this PR adds a python wrapper to the kick. Additionally, the code was refactored to use the Eigen geometry library and rot_conv for rotation conversions. This significantly cleans up the code.

## Necessary checks
- [x] Run `catkin build`
- [x] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

