### PR TITLE
Fix termination of kick

### DIFF
--- a/bitbots_dynamic_kick/src/kick_node.cpp
+++ b/bitbots_dynamic_kick/src/kick_node.cpp
@@ -206,7 +206,7 @@ void KickNode::loopEngine(ros::Rate loop_rate) {
                            bitbots_msgs::KickFeedback::FOOT_LEFT : bitbots_msgs::KickFeedback::FOOT_RIGHT;
     server_.publishFeedback(feedback);
 
-    if (feedback.percent_done == 100) {
+    if (feedback.percent_done >= 100) {
       break;
     }
     joint_goal_publisher_.publish(getJointCommand(motor_goals.value()));


### PR DESCRIPTION
## Proposed changes
Previously, we only checked if `percent_done == 100`. However, in simulation, the timesteps can be large enough to skip directly from `99` to `100`. In that case, the kick just continued to run until `percent_done` overflowed (it is only a `uint8`, so that happened quite fast`) and went back to zero and so on.

## Necessary checks
- [x] Run `catkin build`
- [x] Test on your machine
- [x] Put the PR on our Project board

