### PR TITLE
Additions to kick python interface

### DIFF
--- a/bitbots_dynamic_kick/config/kick_config.yaml
+++ b/bitbots_dynamic_kick/config/kick_config.yaml
@@ -7,9 +7,9 @@ foot_rise: 0.08
 foot_distance: 0.2
 kick_windup_distance: 0.29
 trunk_height: 0.41
-trunk_roll: deg(13.6)
-trunk_pitch: deg(-8.1)
-trunk_yaw: deg(3.5)
+trunk_roll: 0.237
+trunk_pitch: -0.141
+trunk_yaw: 0.0611
 
 # Timings
 move_trunk_time: 0.22

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_engine.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_engine.h
@@ -107,6 +107,11 @@ class KickEngine : public bitbots_splines::AbstractEngine<KickGoals, KickPositio
 
   int getPercentDone() const override;
 
+  /**
+   * Get the current position of the trunk relative to the support foot
+   */
+  geometry_msgs::Pose getTrunkPose();
+
   bitbots_splines::PoseSpline getFlyingSplines() const;
   bitbots_splines::PoseSpline getTrunkSplines() const;
 
@@ -164,11 +169,6 @@ class KickEngine : public bitbots_splines::AbstractEngine<KickGoals, KickPositio
    */
   bool calcIsLeftFootKicking(const Eigen::Vector3d &ball_position,
                              const Eigen::Quaterniond &kick_direction);
-
-  /**
-   * Get the current position of the trunk relative to the support foot
-   */
-  Eigen::Isometry3d getTrunkPose();
 
   /**
    * Calculate the yaw of the kicking foot, so that it is turned

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_node.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_node.h
@@ -74,6 +74,11 @@ class KickNode {
    * Set the current joint state of the robot
    */
   void jointStateCallback(const sensor_msgs::JointState &joint_states);
+
+  /**
+   * Get the current pose of the trunk, relative to the support foot
+   */
+  geometry_msgs::Pose getTrunkPose();
  private:
   ros::NodeHandle node_handle_;
   ros::Publisher joint_goal_publisher_;

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_pywrapper.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_pywrapper.h
@@ -8,6 +8,7 @@
 #include <boost/python.hpp>
 #include <ros/ros.h>
 #include <sensor_msgs/JointState.h>
+#include <geometry_msgs/Pose.h>
 #include <moveit/py_bindings_tools/serialize_msg.h>
 #include <bitbots_dynamic_kick/kick_node.h>
 
@@ -18,6 +19,7 @@ class PyKickWrapper {
   bool set_goal(const std::string &goal_str, const std::string &joint_state_str);
   double get_progress();
   void set_params(boost::python::object params);
+  moveit::py_bindings_tools::ByteString get_trunk_pose();
 
  private:
   std::shared_ptr<bitbots_dynamic_kick::KickNode> kick_node_;

--- a/bitbots_dynamic_kick/package.xml
+++ b/bitbots_dynamic_kick/package.xml
@@ -30,6 +30,7 @@
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>bitbots_splines</depend>
+  <depend>rotconv</depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/bitbots_dynamic_kick/src/bitbots_dynamic_kick/py_kick_wrapper.py
+++ b/bitbots_dynamic_kick/src/bitbots_dynamic_kick/py_kick_wrapper.py
@@ -2,7 +2,7 @@ from io import BytesIO
 
 from moveit_ros_planning_interface._moveit_roscpp_initializer import roscpp_init, roscpp_shutdown
 from sensor_msgs.msg import JointState
-from geometry_msgs.msg import Transform
+from geometry_msgs.msg import Pose
 from bitbots_dynamic_kick.py_dynamic_kick import PyKickWrapper
 from bitbots_msgs.msg import JointCommand, KickGoal
 
@@ -92,3 +92,7 @@ class PyKick:
         :param params_dict: dict where the key is the name of the parameter (str). Does not have to contain all params.
         """
         self.py_kick_wrapper.set_params(params_dict)
+
+    def get_trunk_pose(self) -> Pose:
+        """Returns the current pose of the trunk relative to the support foot"""
+        return from_cpp(self.py_kick_wrapper.get_trunk_pose(), Pose)

--- a/bitbots_dynamic_kick/src/bitbots_dynamic_kick/py_kick_wrapper.py
+++ b/bitbots_dynamic_kick/src/bitbots_dynamic_kick/py_kick_wrapper.py
@@ -56,7 +56,7 @@ class PyKick:
     def __del__(self):
         roscpp_shutdown()
 
-    def set_goal(self, msg: KickGoal, joint_state: JointState):
+    def set_goal(self, msg: KickGoal, joint_state: JointState) -> bool:
         """
         Set a goal for the kick.
 
@@ -66,7 +66,7 @@ class PyKick:
         """
         return self.py_kick_wrapper.set_goal(to_cpp(msg), to_cpp(joint_state))
 
-    def step(self, dt: float, joint_state: JointState):
+    def step(self, dt: float, joint_state: JointState) -> JointCommand:
         """
         Perform a step of the kick engine, must be repeatedly called to perform the full kick.
 
@@ -82,7 +82,7 @@ class PyKick:
         step = self.py_kick_wrapper.step(dt, to_cpp(joint_state))
         return from_cpp(step, JointCommand)
 
-    def get_progress(self):
+    def get_progress(self) -> float:
         """Returns the progress of the kick, between 0 and 1 where 1 is finished."""
         return self.py_kick_wrapper.get_progress()
 

--- a/bitbots_dynamic_kick/src/kick_node.cpp
+++ b/bitbots_dynamic_kick/src/kick_node.cpp
@@ -282,6 +282,10 @@ double KickNode::getProgress() {
   return engine_.getPercentDone() / 100.0;
 }
 
+geometry_msgs::Pose KickNode::getTrunkPose() {
+  return engine_.getTrunkPose();
+}
+
 }
 
 int main(int argc, char *argv[]) {

--- a/bitbots_dynamic_kick/src/kick_pywrapper.cpp
+++ b/bitbots_dynamic_kick/src/kick_pywrapper.cpp
@@ -100,6 +100,11 @@ double PyKickWrapper::get_progress() {
   return kick_node_->getProgress();
 }
 
+moveit::py_bindings_tools::ByteString PyKickWrapper::get_trunk_pose() {
+  std::string trunk_pose_str = to_python<geometry_msgs::Pose>(kick_node_->getTrunkPose());
+  return moveit::py_bindings_tools::serializeMsg(trunk_pose_str);
+}
+
 BOOST_PYTHON_MODULE (py_dynamic_kick) {
   using namespace boost::python;
   using namespace bitbots_dynamic_kick;
@@ -108,5 +113,6 @@ BOOST_PYTHON_MODULE (py_dynamic_kick) {
       .def("set_goal", &PyKickWrapper::set_goal)
       .def("step", &PyKickWrapper::step)
       .def("get_progress", &PyKickWrapper::get_progress)
-      .def("set_params", &PyKickWrapper::set_params);
+      .def("set_params", &PyKickWrapper::set_params)
+      .def("get_trunk_pose", &PyKickWrapper::get_trunk_pose);
 }


### PR DESCRIPTION
## Proposed changes
This pull request adds the function `getTrunkPose()` to the python interface of the kick. The function returns the current pose of the trunk relative to the support foot.
In addition, the rotation parameters have been changed from the `deg()` notation to the actual value in radians. While the `deg` notation is a nice addition to YAML, it is only implemented in the roslaunch yaml parser. When the parameter file is loaded manually, for example for parameter loading, it does not work.

## Necessary checks
- [x] Run `catkin build`
- [x] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

