### PR TITLE
Dynup now keeps stabilizing until robot is stable after completed motion

### DIFF
--- a/bitbots_dynup/cfg/bitbots_dynup_params.cfg
+++ b/bitbots_dynup/cfg/bitbots_dynup_params.cfg
@@ -141,6 +141,12 @@ group_stabilizing.add("stabilizing", bool_t, 4,
                       "Whether to use automatic stabilizing or not")
 group_stabilizing.add("minimal_displacement", bool_t, 4,
                       "Try to stabilize with as little movement as possible")
+group_stabilizing.add("stable_threshold", double_t, 2,
+                      "How much error is still accepted as stable",
+                      min=0, max=10)
+group_stabilizing.add("stable_duration", double_t, 2,
+                      "How long a single stable phase has to be to end the motion [steps]",
+                      min=0, max=10000)
 
 #Visualization params
 group_visualization = gen.add_group("Visualization", type="tab")

--- a/bitbots_dynup/config/dynup_robot.yaml
+++ b/bitbots_dynup/config/dynup_robot.yaml
@@ -51,6 +51,8 @@ dynup:
   # Stabilier
   stabilizing: True
   minimal_displacement: False
+  stable_threshold: 0.05
+  stable_duration: 100
 
   # Visualizer
   spline_smoothness: 100

--- a/bitbots_dynup/config/dynup_sim.yaml
+++ b/bitbots_dynup/config/dynup_sim.yaml
@@ -53,6 +53,8 @@ dynup:
   # Stabilier
   stabilizing: False
   minimal_displacement: False
+  stable_threshold: 0.05
+  stable_duration: 100
 
   # Visualizer
   spline_smoothness: 100

--- a/bitbots_dynup/config/dynup_sim_darwin.yaml
+++ b/bitbots_dynup/config/dynup_sim_darwin.yaml
@@ -50,6 +50,8 @@ dynup:
   # Stabilier
   stabilizing: False
   minimal_displacement: False
+  stable_threshold: 0.05
+  stable_duration: 100
 
   # Visualizer
   spline_smoothness: 100

--- a/bitbots_dynup/include/bitbots_dynup/dynup_node.h
+++ b/bitbots_dynup/include/bitbots_dynup/dynup_node.h
@@ -81,6 +81,8 @@ class DynUpNode {
   Stabilizer stabilizer_;
   Visualizer visualizer_;
   DynupIK ik_;
+  DynUpConfig params_;
+  int stable_duration_;
   int engine_rate_;
   double last_ros_update_time_;
   bool debug_;

--- a/bitbots_dynup/include/bitbots_dynup/dynup_stabilizer.h
+++ b/bitbots_dynup/include/bitbots_dynup/dynup_stabilizer.h
@@ -8,6 +8,7 @@
 #include <tf2_ros/transform_listener.h>
 #include <bitbots_splines/abstract_stabilizer.h>
 #include "dynup_utils.h"
+#include <bitbots_dynup/DynUpConfig.h>
 #include <moveit/robot_state/robot_state.h>
 #include <tf2_ros/transform_listener.h>
 #include <control_toolbox/pid.h>
@@ -24,10 +25,11 @@ class Stabilizer : public bitbots_splines::AbstractStabilizer<DynupResponse> {
   void init(moveit::core::RobotModelPtr kinematic_model);
   DynupResponse stabilize(const DynupResponse &response, const ros::Duration &dt) override;
   void setRSoleToTrunk(geometry_msgs::TransformStamped r_sole_to_trunk);
-  void useStabilizing(bool use);
+  void setParams(DynUpConfig params);
   void setRobotModel(moveit::core::RobotModelPtr model); 
   void reset() override;
   void setImu(sensor_msgs::Imu imu);
+  bool isStable();
 
 
 private:
@@ -40,6 +42,9 @@ private:
   geometry_msgs::TransformStamped r_sole_to_trunk_;
 
   bool stabilize_now_;
+
+  bool is_stable_;
+  double stable_threshold_;
 
   bool use_stabilizing_;
 };

--- a/bitbots_dynup/src/dynup_engine.cpp
+++ b/bitbots_dynup/src/dynup_engine.cpp
@@ -150,6 +150,7 @@ void DynupEngine::publishArrowMarker(std::string name_space,
 }
 
 DynupResponse DynupEngine::update(double dt) {
+  time_ = std::min(time_, duration_);
   // TODO what happens when splines for foot and trunk are not present?
   /* Get should-be pose from planned splines (every axis) at current time */
   tf2::Transform l_foot_pose = l_foot_spline_.getTfTransform(time_);
@@ -675,7 +676,7 @@ bool DynupEngine::isStabilizingNeeded() const {
                                         params_.time_foot_ground_back +
                                         params_.time_full_squat_hands +
                                         params_.time_full_squat_legs) ||
-           (direction_ == 2) || (direction_ == 3)) && getPercentDone() < 99;
+           (direction_ == 2) || (direction_ == 3));
 }
 
 bitbots_splines::PoseSpline DynupEngine::getRFootSplines() const {

--- a/bitbots_dynup/src/dynup_stabilizer.cpp
+++ b/bitbots_dynup/src/dynup_stabilizer.cpp
@@ -47,6 +47,9 @@ DynupResponse Stabilizer::stabilize(const DynupResponse &ik_goals, const ros::Du
         goal_fused.fusedPitch += pid_trunk_pitch_.computeCommand(goal_fused.fusedPitch - current_orientation.fusedPitch, dt);
         goal_fused.fusedRoll += pid_trunk_roll_.computeCommand(goal_fused.fusedRoll - current_orientation.fusedRoll, dt);
 
+        is_stable_ = (abs(goal_fused.fusedPitch - current_orientation.fusedPitch) < stable_threshold_) &&
+                (abs(goal_fused.fusedRoll - current_orientation.fusedRoll) < stable_threshold_);
+
         tf2::Quaternion corrected_orientation;
         Eigen::Quaterniond goal_orientation_eigen_corrected = rot_conv::QuatFromFused(goal_fused);
         tf2::convert(goal_orientation_eigen_corrected, corrected_orientation);
@@ -72,8 +75,14 @@ DynupResponse Stabilizer::stabilize(const DynupResponse &ik_goals, const ros::Du
     return response;
 }
 
-void Stabilizer::useStabilizing(bool use) {
-  use_stabilizing_ = use;
+void Stabilizer::setParams(DynUpConfig params) {
+  use_stabilizing_ = params.stabilizing;
+  stable_threshold_ = params.stable_threshold;
+
+}
+
+bool Stabilizer::isStable() {
+    return is_stable_;
 }
 
 


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes and why they are necessary. -->
This pull request adds two new parameters. After a dynup request is completed, if stabilizing is enabled, the PD controller will keep regulating the motion until the robots absolute fused error is below `stable_threshold` for `stable_duration` cycles.

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
Closes #230 

## Necessary checks
- ~[ ] Update package version~
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [x] Test on the robot
- [x] Put the PR on our Project board

