### PR TITLE
Refactor the odometry fuser

### DIFF
--- a/bitbots_odometry/CMakeLists.txt
+++ b/bitbots_odometry/CMakeLists.txt
@@ -10,6 +10,7 @@ project(bitbots_odometry)
 find_package(catkin REQUIRED COMPONENTS
   nav_msgs
   sensor_msgs
+  message_filters
   tf2
   tf2_ros
   tf2_geometry_msgs

--- a/bitbots_odometry/include/bitbots_odometry/odometry_fuser.h
+++ b/bitbots_odometry/include/bitbots_odometry/odometry_fuser.h
@@ -27,12 +27,12 @@ class OdometryFuser {
  public:
   OdometryFuser();
  private:
-  sensor_msgs::Imu _imu_data;
-  nav_msgs::Odometry _odom_data;
-  geometry_msgs::TransformStamped tf;
+  sensor_msgs::Imu imu_data_;
+  nav_msgs::Odometry odom_data_;
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
-  std::string base_link_frame_, r_sole_frame_, l_sole_frame_, odom_frame_, rotation_frame_, imu_frame_, cop_frame_;
+  ros::Time fused_time_;
+  std::string base_link_frame_, r_sole_frame_, l_sole_frame_, odom_frame_, rotation_frame_, imu_frame_;
 
   message_filters::Cache<bitbots_msgs::SupportState> support_state_cache_;
 

--- a/bitbots_odometry/include/bitbots_odometry/odometry_fuser.h
+++ b/bitbots_odometry/include/bitbots_odometry/odometry_fuser.h
@@ -17,6 +17,9 @@
 #include <Eigen/Geometry>
 #include <rot_conv/rot_conv.h>
 #include <bitbots_msgs/SupportState.h>
+#include <message_filters/subscriber.h>
+#include <message_filters/synchronizer.h>
+#include <message_filters/sync_policies/approximate_time.h>
 
 
 class OdometryFuser {
@@ -25,18 +28,13 @@ class OdometryFuser {
  private:
   sensor_msgs::Imu _imu_data;
   nav_msgs::Odometry _odom_data;
-  ros::Time _imu_update_time;
-  ros::Time _odom_update_time;
   geometry_msgs::TransformStamped tf;
   char current_support_state_;
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
-  tf2::Quaternion last_quat_;
-  tf2::Quaternion last_quat_imu_;
   std::string base_link_frame_, r_sole_frame_, l_sole_frame_, odom_frame_, rotation_frame_, imu_frame_, cop_frame_;
 
-  void imuCallback(const sensor_msgs::Imu::ConstPtr &msg);
-  void odomCallback(const nav_msgs::Odometry::ConstPtr &msg);
+  void imuCallback(const sensor_msgs::Imu::ConstPtr &img_msg, const nav_msgs::Odometry::ConstPtr &motion_odom_msg);
   void supportCallback(const bitbots_msgs::SupportState msg);
   tf2::Quaternion getCurrentMotionOdomYaw(tf2::Quaternion motion_odom_rotation);
   tf2::Quaternion getCurrentImuRotationWithoutYaw(tf2::Quaternion imu_rotation);

--- a/bitbots_odometry/include/bitbots_odometry/odometry_fuser.h
+++ b/bitbots_odometry/include/bitbots_odometry/odometry_fuser.h
@@ -16,10 +16,11 @@
 #include <tf2/LinearMath/Transform.h>
 #include <Eigen/Geometry>
 #include <rot_conv/rot_conv.h>
-#include <bitbots_msgs/SupportState.h>
+#include <message_filters/cache.h>
 #include <message_filters/subscriber.h>
 #include <message_filters/synchronizer.h>
 #include <message_filters/sync_policies/approximate_time.h>
+#include <bitbots_msgs/SupportState.h>
 
 
 class OdometryFuser {
@@ -29,13 +30,13 @@ class OdometryFuser {
   sensor_msgs::Imu _imu_data;
   nav_msgs::Odometry _odom_data;
   geometry_msgs::TransformStamped tf;
-  char current_support_state_;
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
   std::string base_link_frame_, r_sole_frame_, l_sole_frame_, odom_frame_, rotation_frame_, imu_frame_, cop_frame_;
 
+  message_filters::Cache<bitbots_msgs::SupportState> support_state_cache_;
+
   void imuCallback(const sensor_msgs::Imu::ConstPtr &img_msg, const nav_msgs::Odometry::ConstPtr &motion_odom_msg);
-  void supportCallback(const bitbots_msgs::SupportState msg);
   tf2::Quaternion getCurrentMotionOdomYaw(tf2::Quaternion motion_odom_rotation);
   tf2::Quaternion getCurrentImuRotationWithoutYaw(tf2::Quaternion imu_rotation);
   tf2::Transform getCurrentRotationPoint();

--- a/bitbots_odometry/package.xml
+++ b/bitbots_odometry/package.xml
@@ -14,6 +14,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <depend>nav_msgs</depend>
+  <depend>message_filters</depend>
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>

--- a/bitbots_odometry/src/odometry_fuser.cpp
+++ b/bitbots_odometry/src/odometry_fuser.cpp
@@ -51,7 +51,7 @@ OdometryFuser::OdometryFuser() : tf_listener_(tf_buffer_), support_state_cache_(
     ROS_WARN_THROTTLE(30, "Waiting for transforms from robot joints");
   }
 
-  ros::Rate r(200.0);
+  ros::Rate r(500.0);
   ros::Time last_time_stamp;
   while (ros::ok()) {
     ros::spinOnce();


### PR DESCRIPTION
## Proposed changes
* Refactor the odometry fuser
* Use `message_filters` to sync the messages before fusing them.

## Necessary checks
- [x] Run `catkin build`
- [x] Write documentation
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

