### PR TITLE
Fix invalid yaml in dynup config

### DIFF
--- a/bitbots_dynup/config/dynup_robot.yaml
+++ b/bitbots_dynup/config/dynup_robot.yaml
@@ -3,7 +3,7 @@ dynup:
   engine_rate: 240
 
   # end pose
-  arm_extended_length:0.3
+  arm_extended_length: 0.3
   trunk_height: 0.4
   trunk_pitch: 0
   foot_distance: 0.2


### PR DESCRIPTION
## Proposed changes
The space between the colon and the number is missing, making the yaml invalid.

## Related issues
Introduced in 56fb7b6e7c957c9fed3731d57b46907eef3cdf7a in #222.

## Necessary checks
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

