### PR TITLE
Change the walkready pose in dynup

### DIFF
--- a/bitbots_dynup/cfg/bitbots_dynup_params.cfg
+++ b/bitbots_dynup/cfg/bitbots_dynup_params.cfg
@@ -25,6 +25,9 @@ group_engine.add("trunk_x_final", double_t, 2,
 group_engine.add("hand_walkready_pitch", double_t, 2,
                  "Pitch of the hand at the end [deg]",
                  min=-90, max=90)
+group_engine.add("hand_walkready_height", double_t, 2,
+                 "Relative height of the hand at the end [m]",
+                 min=-1, max=1)
 group_engine.add("trunk_height", double_t, 2,
                  "Height of the trunk at the end [m]",
                  min=0, max=10)

--- a/bitbots_dynup/config/dynup_robot.yaml
+++ b/bitbots_dynup/config/dynup_robot.yaml
@@ -9,6 +9,7 @@ dynup:
   foot_distance: 0.2
   trunk_x_final: -0.025
   hand_walkready_pitch: -25.0
+  hand_walkready_height: -0.35
 
   # Back
   leg_min_length_back: 0.22

--- a/bitbots_dynup/config/dynup_robot.yaml
+++ b/bitbots_dynup/config/dynup_robot.yaml
@@ -8,7 +8,7 @@ dynup:
   trunk_pitch: 0
   foot_distance: 0.2
   trunk_x_final: -0.025
-  hand_walkready_pitch: -60
+  hand_walkready_pitch: -25.0
 
   # Back
   leg_min_length_back: 0.22

--- a/bitbots_dynup/config/dynup_sim.yaml
+++ b/bitbots_dynup/config/dynup_sim.yaml
@@ -6,6 +6,7 @@ dynup:
   arm_extended_length: 0.3
   foot_distance: 0.2
   hand_walkready_pitch: -25.0
+  hand_walkready_height: -0.35
   trunk_height: 0.4
   trunk_pitch: 0.0
   trunk_x_final: 0

--- a/bitbots_dynup/config/dynup_sim.yaml
+++ b/bitbots_dynup/config/dynup_sim.yaml
@@ -5,7 +5,7 @@ dynup:
   # end pose
   arm_extended_length: 0.3
   foot_distance: 0.2
-  hand_walkready_pitch: -60.0
+  hand_walkready_pitch: -25.0
   trunk_height: 0.4
   trunk_pitch: 0.0
   trunk_x_final: 0

--- a/bitbots_dynup/src/dynup_engine.cpp
+++ b/bitbots_dynup/src/dynup_engine.cpp
@@ -192,7 +192,7 @@ double DynupEngine::calcFrontSplines() {
   /*
   calculates splines for front up
   */
-  
+
   /*
    * Pose 0: Extend hands to the side, for later turning
    */
@@ -562,13 +562,13 @@ double DynupEngine::calcRiseSplines(double time) {
 
   l_hand_spline_.x()->addPoint(time, 0);
   l_hand_spline_.y()->addPoint(time, 0);
-  l_hand_spline_.z()->addPoint(time, 0);
+  l_hand_spline_.z()->addPoint(time, -0.35);
   l_hand_spline_.roll()->addPoint(time, 0);
   l_hand_spline_.pitch()->addPoint(time, params_.hand_walkready_pitch * M_PI/180);
   l_hand_spline_.yaw()->addPoint(time, 0);
   r_hand_spline_.x()->addPoint(time, 0);
   r_hand_spline_.y()->addPoint(time, 0);
-  r_hand_spline_.z()->addPoint(time, 0);
+  r_hand_spline_.z()->addPoint(time, -0.35);
   r_hand_spline_.roll()->addPoint(time, 0);
   r_hand_spline_.pitch()->addPoint(time, params_.hand_walkready_pitch * M_PI/180);
   r_hand_spline_.yaw()->addPoint(time, 0);

--- a/bitbots_dynup/src/dynup_engine.cpp
+++ b/bitbots_dynup/src/dynup_engine.cpp
@@ -562,13 +562,13 @@ double DynupEngine::calcRiseSplines(double time) {
 
   l_hand_spline_.x()->addPoint(time, 0);
   l_hand_spline_.y()->addPoint(time, 0);
-  l_hand_spline_.z()->addPoint(time, -0.35);
+  l_hand_spline_.z()->addPoint(time, params_.hand_walkready_height);
   l_hand_spline_.roll()->addPoint(time, 0);
   l_hand_spline_.pitch()->addPoint(time, params_.hand_walkready_pitch * M_PI/180);
   l_hand_spline_.yaw()->addPoint(time, 0);
   r_hand_spline_.x()->addPoint(time, 0);
   r_hand_spline_.y()->addPoint(time, 0);
-  r_hand_spline_.z()->addPoint(time, -0.35);
+  r_hand_spline_.z()->addPoint(time, params_.hand_walkready_height);
   r_hand_spline_.roll()->addPoint(time, 0);
   r_hand_spline_.pitch()->addPoint(time, params_.hand_walkready_pitch * M_PI/180);
   r_hand_spline_.yaw()->addPoint(time, 0);


### PR DESCRIPTION
## Proposed changes
* Changes Dynup param to create a new walkready pose.
* This is done to reduce the visibility of th arms in the camera image.
* 
## Related issues
bit-bots/wolfgang_robot#125

## Necessary checks
- [x] Run `catkin build`
- [x] Test on your machine
- [x] Put the PR on our Project board

