### PR TITLE
kick: add is_left_kick method to python interface

### DIFF
--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_node.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_node.h
@@ -79,6 +79,11 @@ class KickNode {
    * Get the current pose of the trunk, relative to the support foot
    */
   geometry_msgs::Pose getTrunkPose();
+
+  /**
+   * Whether the left foot is the current kicking foot
+   */
+  bool isLeftKick();
  private:
   ros::NodeHandle node_handle_;
   ros::Publisher joint_goal_publisher_;

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_pywrapper.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_pywrapper.h
@@ -20,6 +20,7 @@ class PyKickWrapper {
   double get_progress();
   void set_params(boost::python::object params);
   moveit::py_bindings_tools::ByteString get_trunk_pose();
+  bool is_left_kick();
 
  private:
   std::shared_ptr<bitbots_dynamic_kick::KickNode> kick_node_;

--- a/bitbots_dynamic_kick/src/bitbots_dynamic_kick/py_kick_wrapper.py
+++ b/bitbots_dynamic_kick/src/bitbots_dynamic_kick/py_kick_wrapper.py
@@ -96,3 +96,7 @@ class PyKick:
     def get_trunk_pose(self) -> Pose:
         """Returns the current pose of the trunk relative to the support foot"""
         return from_cpp(self.py_kick_wrapper.get_trunk_pose(), Pose)
+
+    def is_left_kick(self) -> bool:
+        """Returns if the left foot is the currently kicking foot"""
+        return self.py_kick_wrapper.is_left_kick()

--- a/bitbots_dynamic_kick/src/kick_node.cpp
+++ b/bitbots_dynamic_kick/src/kick_node.cpp
@@ -286,6 +286,10 @@ geometry_msgs::Pose KickNode::getTrunkPose() {
   return engine_.getTrunkPose();
 }
 
+bool KickNode::isLeftKick() {
+  return engine_.isLeftKick();
+}
+
 }
 
 int main(int argc, char *argv[]) {

--- a/bitbots_dynamic_kick/src/kick_pywrapper.cpp
+++ b/bitbots_dynamic_kick/src/kick_pywrapper.cpp
@@ -105,6 +105,10 @@ moveit::py_bindings_tools::ByteString PyKickWrapper::get_trunk_pose() {
   return moveit::py_bindings_tools::serializeMsg(trunk_pose_str);
 }
 
+bool PyKickWrapper::is_left_kick() {
+  return kick_node_->isLeftKick();
+}
+
 BOOST_PYTHON_MODULE (py_dynamic_kick) {
   using namespace boost::python;
   using namespace bitbots_dynamic_kick;
@@ -114,5 +118,6 @@ BOOST_PYTHON_MODULE (py_dynamic_kick) {
       .def("step", &PyKickWrapper::step)
       .def("get_progress", &PyKickWrapper::get_progress)
       .def("set_params", &PyKickWrapper::set_params)
-      .def("get_trunk_pose", &PyKickWrapper::get_trunk_pose);
+      .def("get_trunk_pose", &PyKickWrapper::get_trunk_pose)
+      .def("is_left_kick", &PyKickWrapper::is_left_kick);
 }


### PR DESCRIPTION
## Proposed changes
This adds a method `is_left_kick()` to the python interface. It is needed for the reinforcement-learned kick.

## Necessary checks
- [x] Run `catkin build`
- [x] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

