### PR TITLE
Add animation cache and fix torque in animations

### DIFF
--- a/bitbots_animation_server/config/animation.yaml
+++ b/bitbots_animation_server/config/animation.yaml
@@ -1,1 +1,0 @@
-animation:

--- a/bitbots_animation_server/launch/animation.launch
+++ b/bitbots_animation_server/launch/animation.launch
@@ -4,7 +4,6 @@
     <arg if="$(optenv IS_ROBOT false)" name="taskset" default="taskset -c 3"/>
     <arg unless="$(optenv IS_ROBOT false)" name="taskset" default=""/>
 
-    <!--<rosparam file="$(find bitbots_animation_server)/config/animation.yaml" command="load"/>-->
     <group if="$(arg use_game_settings)">
             <rosparam command="load" file="$(find bitbots_bringup)/config/game_settings.yaml" />
     </group>

--- a/bitbots_animation_server/scripts/animation_hcm_bridge.py
+++ b/bitbots_animation_server/scripts/animation_hcm_bridge.py
@@ -36,5 +36,6 @@ class AnimationHcmBridge:
 
         self.joint_publisher.publish(self.joint_command_msg)
 
+
 if __name__ == '__main__':
     bridge = AnimationHcmBridge()

--- a/bitbots_animation_server/scripts/run_animation.py
+++ b/bitbots_animation_server/scripts/run_animation.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf8 -*-
 import actionlib
 from actionlib_msgs.msg import GoalStatus
 import rospy
@@ -52,7 +51,6 @@ def anim_run(anim=None, hcm=False):
 
 if __name__ == '__main__':
     # run with "rosrun bitbots_animation_server run_animation.py NAME"
-    #print("Deactivate evaluation of state machine in hcm befor using this, maybe")
     if len(sys.argv) > 1:
         # Support for _anim:=NAME -style execution for legacy reasons
         if sys.argv[1].startswith('_anim:=') or sys.argv[1].startswith('anim:='):

--- a/bitbots_animation_server/src/bitbots_animation_server/animation.py
+++ b/bitbots_animation_server/src/bitbots_animation_server/animation.py
@@ -1,14 +1,7 @@
-# -*- coding:utf-8 -*-
-
-import time
-
-import math
-import rospy
-
 class Keyframe:
-    '''
+    """
     A pose which the robot reaches at :attr:`duration` seconds in the future.
-    '''
+    """
 
     def __init__(self, goals, torque={}, duration=1.0, pause=0.0, p={}):
         self.duration = float(duration)
@@ -19,10 +12,10 @@ class Keyframe:
 
 
 class Animation:
-    '''
+    """
     An animation is constructed by an array of goal positions (:class:`Keyframe`).
     Between two keyframes, the goal positions are interpolated by an  :class:`Interpolator`.
-    '''
+    """
 
     def __init__(self, name, keyframes, default_interpolator=None):
         self.name = name
@@ -31,10 +24,10 @@ class Animation:
 
 
 def parse(info):
-    '''
+    """
     This method is parsing an animation from a :class:`dict`
     instance *info*, as created by :func:`as_dict`.
-    '''
+    """
     anim = Animation(info["name"], ())
 
     keyframes = info.get("keyframes", ())
@@ -45,10 +38,10 @@ def parse(info):
 
 
 def as_dict(anim):
-    '''
+    """
     Convert an animation to builtin python types to
     make it serializable to formats like ``json``.
-    '''
+    """
     return {
         "name": anim.name,
         "default_interpolator": anim.default_interpolator.__name__,

--- a/bitbots_animation_server/src/bitbots_animation_server/animation_node.py
+++ b/bitbots_animation_server/src/bitbots_animation_server/animation_node.py
@@ -27,7 +27,7 @@ class AnimationNode:
         """Starts a simple action server and waits for requests."""
         # currently we set log level to info since the action server is spamming to much
         log_level = rospy.INFO if rospy.get_param("debug_active", False) else rospy.INFO
-        rospy.init_node("bitbots_animation_server", log_level=log_level, anonymous=False)
+        rospy.init_node("animation", log_level=log_level, anonymous=False)
         rospy.on_shutdown(self.on_shutdown_hook)
         rospy.logdebug("Starting Animation Server")
         server = PlayAnimationAction(rospy.get_name())

--- a/bitbots_animation_server/src/bitbots_animation_server/resource_manager.py
+++ b/bitbots_animation_server/src/bitbots_animation_server/resource_manager.py
@@ -163,18 +163,23 @@ class ResourceManager(object):
         returns a list of all animation-paths in the system.
         """
         if not self.files or force_reload:
-            def add_anim(arg, dirnames, fnames):
-                """ Reiht die aufgefundenen Dateien auf,
-                vorausgesetzt es sind .jsons :)
-                """
-                for f in fnames:
+            path = self.find_resource('animations/')
+            for root, _, filenames in os.walk(path):
+                for f in filenames:
                     name, dot, extension = f.rpartition('.')
                     if extension == 'json':
-                        self.files.append(os.path.join(dirnames, f))
+                        self.files.append(os.path.join(root, f))
                         self.names.append(name)
-            path = find_resource('animations/')
-            os.path.walk(path, add_anim, None)
         return self.files
+
+    def find_all_animations_by_name(self, force_reload=False):
+        """Finds all animations in the animations directory.
+
+        returns a dict from animation names to animation paths
+        """
+        if not self.files or force_reload:
+            self.find_all_animations(force_reload)
+        return dict(zip(self.names, self.files))
 
     def find_all_animation_names(self, force_reload=False):
         """ Same as find_all_animations, but returns a sorted set of the animations
@@ -193,8 +198,8 @@ class ResourceManager(object):
 
 _RM = None  # type: ResourceManager
 # Shortcut to search for animations
-def find_animation(*args, **kwargs):
+def find_all_animations_by_name(*args, **kwargs):
     global _RM
     if not _RM:
         _RM = ResourceManager()
-    return _RM.find_animation(*args, **kwargs)
+    return _RM.find_all_animations_by_name(*args, **kwargs)

--- a/bitbots_animation_server/src/bitbots_animation_server/resource_manager.py
+++ b/bitbots_animation_server/src/bitbots_animation_server/resource_manager.py
@@ -1,11 +1,10 @@
-#-*- coding:utf-8 -*-
 """
 ResourceManager
 ^^^^^^^^^^^^^^^
 
 The ResourceManager module provides functions for file searching in a
 Darwin Project. Thus, it is possible to find resources without knowing
-the currend location in the file system.
+the current location in the file system.
 
 This module provides the global methods :func:`find_resource`,
 :func:`find_anim` and :func:`find` which use a single global instance
@@ -16,10 +15,8 @@ discovered do not have to be searched again.
 import os.path
 from os.path import abspath, dirname, exists, join, normpath
 from os import walk
-# get an instance of RosPack with the default search paths
 import rospkg as rospkg
 import rospy
-
 
 
 class ResourceManager(object):
@@ -48,7 +45,7 @@ class ResourceManager(object):
         :type filename: String
         :raises: IOError
         :return: absolute path to the file
-        :returntype: String
+        :rtype: String
 
         This method searches in all folders in `path` recursively for the file
         specified in folders + filename. If folders is a list, every item of the list will
@@ -98,7 +95,7 @@ class ResourceManager(object):
         :type filename: String
         :raises: IOError
         :return: Absolute path to the file
-        :returntype: String
+        :rtype: String
 
         Searches the requested resource using :func:`search` with
         folders = name and filename = filename, and saves the result to
@@ -190,7 +187,7 @@ class ResourceManager(object):
         return sorted(set(self.names))
 
     def is_animation_name(self, name, force_reload=False):
-        """Check if a name belongs to a safed animation
+        """Check if a name belongs to a saved animation
         """
         if not self.names or force_reload:
             self.find_all_animations(force_reload=True)

--- a/bitbots_animation_server/src/bitbots_animation_server/spline_animator.py
+++ b/bitbots_animation_server/src/bitbots_animation_server/spline_animator.py
@@ -1,9 +1,8 @@
 import math
 
-import numpy as np
 import rospy
-from bitbots_animation_server.animation import Keyframe, Animation
 from bitbots_splines.smooth_spline import SmoothSpline
+
 
 class SplineAnimator:
 
@@ -15,14 +14,14 @@ class SplineAnimator:
         self.spline_dict = {}
         self.torques = {}
 
-        #add current joint positions as start
+        # add current joint positions as start
         if current_joint_states is not None:
             i = 0
             for joint in current_joint_states.name:
                 if joint not in self.spline_dict:
-                        self.spline_dict[joint] = SmoothSpline()
+                    self.spline_dict[joint] = SmoothSpline()
                 self.spline_dict[joint].add_point(0, math.degrees(current_joint_states.position[i]))
-                i+=1
+                i += 1
         else:
             rospy.logwarn("No current joint positions. Will play animation starting from first keyframe.")
             for joint in self.anim.keyframes[0].goals:
@@ -30,23 +29,22 @@ class SplineAnimator:
                     self.spline_dict[joint] = SmoothSpline()
                 self.spline_dict[joint].add_point(0, self.anim.keyframes[0].goals[joint])
 
-        #load keyframe positions into the splines
-        for keyframe in self.anim.keyframes:            
+        # load keyframe positions into the splines
+        for keyframe in self.anim.keyframes:
             self.animation_duration += keyframe.duration + keyframe.pause
             self.current_point_time += keyframe.duration
             for joint in keyframe.goals:
                 if joint not in self.spline_dict:
                     self.spline_dict[joint] = SmoothSpline()
                 self.spline_dict[joint].add_point(self.current_point_time, keyframe.goals[joint])
-                self.spline_dict[joint].add_point(self.current_point_time + keyframe.pause, keyframe.goals[joint])                
+                self.spline_dict[joint].add_point(self.current_point_time + keyframe.pause, keyframe.goals[joint])
             self.current_point_time += keyframe.pause
             self.torques[self.current_point_time] = keyframe.torque
 
         # compute the splines
         for joint in self.spline_dict:
             self.spline_dict[joint].compute_spline()
-         
-    
+
     def get_positions_deg(self, time):
         if time < 0 or time > self.animation_duration:
             return None
@@ -54,7 +52,7 @@ class SplineAnimator:
         for joint in self.spline_dict:
             ret_dict[joint] = self.spline_dict[joint].pos(time)
         return ret_dict
-    
+
     def get_positions_rad(self, time):
         if time < 0 or time > self.animation_duration:
             return None


### PR DESCRIPTION
## Proposed changes
This PR includes two changes:
1. Add a cache to animations so that the json files are not read every time again
2. Fix torque reading, currently the torque value of the last keyframe is used for all keyframes

## Related issues
This touches #208, but reads the animation when it is used for the first time because we have no way of knowing which animations will be used. Should we just load all animations? Or specify a list in the config file?

## Necessary checks
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

