### PR TITLE
Add missing dependencies

### DIFF
--- a/bitbots_dynamic_kick/package.xml
+++ b/bitbots_dynamic_kick/package.xml
@@ -31,6 +31,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>bitbots_splines</depend>
   <depend>rotconv</depend>
+  <depend>control_toolbox</depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/bitbots_dynup/package.xml
+++ b/bitbots_dynup/package.xml
@@ -24,6 +24,7 @@
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>rotconv</depend>
+  <depend>control_toolbox</depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/bitbots_quintic_walk/package.xml
+++ b/bitbots_quintic_walk/package.xml
@@ -38,6 +38,7 @@
   <depend>moveit_ros_planning_interface</depend>
   <depend>bitbots_docs</depend>
   <depend>rotconv</depend>
+  <depend>control_toolbox</depend>
 
   <test_depend>plotjuggler</test_depend>
   <test_depend>bitbots_odometry</test_depend>


### PR DESCRIPTION
## Proposed changes
This adds the `control_toolbox` dependency to the package.xml files.

## Necessary checks
- [ ] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

