### PR TITLE
HCM: Fix duplicate definition of robot states

### DIFF
--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/actions/cancel_goals.py
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/actions/cancel_goals.py
@@ -5,7 +5,7 @@ from dynamic_stack_decider.abstract_action_element import AbstractActionElement
 class CancelGoals(AbstractActionElement):
 
     def __init__(self, blackboard, dsd, parameters=None):
-        super(AbstractActionElement, self).__init__(blackboard, dsd, parameters)
+        super(CancelGoals, self).__init__(blackboard, dsd, parameters)
 
     def perform(self):
         self.blackboard.dynup_action_client.cancel_all_goals()

--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/actions/change_motor_power.py
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/actions/change_motor_power.py
@@ -1,8 +1,5 @@
 import rospy
-import humanoid_league_msgs.msg
 from dynamic_stack_decider.abstract_action_element import AbstractActionElement
-import bitbots_hcm.hcm_dsd.hcm_blackboard
-from bitbots_hcm.hcm_dsd.hcm_blackboard import STATE_HARDWARE_PROBLEM
 from std_srvs.srv import SetBool
 
 

--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/actions/play_animation.py
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/actions/play_animation.py
@@ -3,8 +3,10 @@ import actionlib
 import humanoid_league_msgs.msg
 import bitbots_msgs.msg
 from dynamic_stack_decider.abstract_action_element import AbstractActionElement
-from bitbots_hcm.hcm_dsd.hcm_blackboard import HcmBlackboard, STATE_GETTING_UP
+from bitbots_hcm.hcm_dsd.hcm_blackboard import HcmBlackboard
 from time import sleep
+
+from humanoid_league_msgs.msg import RobotControlState
 
 
 class AbstractPlayAnimation(AbstractActionElement):
@@ -84,28 +86,28 @@ class AbstractPlayAnimation(AbstractActionElement):
 
 class PlayAnimationStandUpFront(AbstractPlayAnimation):
     def chose_animation(self):
-        self.blackboard.current_state = STATE_GETTING_UP
+        self.blackboard.current_state = RobotControlState.GETTING_UP
         rospy.loginfo("PLAYING STAND UP FRONT ANIMATION")
         return self.blackboard.stand_up_front_animation
 
 
 class PlayAnimationStandUpBack(AbstractPlayAnimation):
     def chose_animation(self):
-        self.blackboard.current_state = STATE_GETTING_UP
+        self.blackboard.current_state = RobotControlState.GETTING_UP
         rospy.loginfo("PLAYING STAND UP BACK ANIMATION")
         return self.blackboard.stand_up_back_animation
 
 
 class PlayAnimationStandUpLeft(AbstractPlayAnimation):
     def chose_animation(self):
-        self.blackboard.current_state = STATE_GETTING_UP
+        self.blackboard.current_state = RobotControlState.GETTING_UP
         rospy.loginfo("PLAYING STAND UP LEFT ANIMATION")
         return self.blackboard.stand_up_left_animation
 
 
 class PlayAnimationStandUpRight(AbstractPlayAnimation):
     def chose_animation(self):
-        self.blackboard.current_state = STATE_GETTING_UP
+        self.blackboard.current_state = RobotControlState.GETTING_UP
         rospy.loginfo("PLAYING STAND UP RIGHT ANIMATION")
         return self.blackboard.stand_up_right_animation
 

--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/actions/stay.py
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/actions/stay.py
@@ -1,7 +1,8 @@
 import rospy
 import humanoid_league_msgs.msg
 from dynamic_stack_decider.abstract_action_element import AbstractActionElement
-from bitbots_hcm.hcm_dsd.hcm_blackboard import HcmBlackboard, STATE_HCM_OFF, STATE_PENALTY, STATE_CONTROLLABLE
+from bitbots_hcm.hcm_dsd.hcm_blackboard import HcmBlackboard
+from humanoid_league_msgs.msg import RobotControlState
 
 
 class AbstractStay(AbstractActionElement):
@@ -21,7 +22,7 @@ class AbstractStay(AbstractActionElement):
 
 class StayControlable(AbstractStay):
     def perform(self):
-        self.blackboard.current_state = STATE_CONTROLLABLE
+        self.blackboard.current_state = RobotControlState.CONTROLLABLE
 
 
 class StayWalking(AbstractStay):
@@ -42,7 +43,7 @@ class StayMotorsOff(AbstractStay):
 
 class StayStopped(AbstractStay):
     def perform(self):
-        self.blackboard.current_state = STATE_PENALTY
+        self.blackboard.current_state = RobotControlState.PENALTY
 
 
 class StayRecord(AbstractStay):
@@ -51,7 +52,7 @@ class StayRecord(AbstractStay):
 
 class StayShutDown(AbstractStay):
     def perform(self):
-        self.blackboard.current_state = STATE_HCM_OFF
+        self.blackboard.current_state = RobotControlState.HCM_OFF
 
 class StayKicking(AbstractStay):
     pass

--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/actions/stop_walking.py
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/actions/stop_walking.py
@@ -1,6 +1,6 @@
-from bitbots_hcm.hcm_dsd.hcm_blackboard import STATE_PENALTY
 from dynamic_stack_decider.abstract_action_element import AbstractActionElement
 from geometry_msgs.msg import Twist
+from humanoid_league_msgs.msg import RobotControlState
 
 
 class StopWalking(AbstractActionElement):
@@ -29,6 +29,6 @@ class ForceStopWalking(AbstractActionElement):
         msg.linear.y = 0
         msg.angular.z = 0
         self.blackboard.walk_pub.publish(msg)
-        self.blackboard.current_state = STATE_PENALTY
+        self.blackboard.current_state = RobotControlState.PENALTY
         # We can pop immediately because the state is PENALTY on no walking messages will be passed
         self.pop()

--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/decisions/decisions.py
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/decisions/decisions.py
@@ -1,10 +1,7 @@
 import rospy
 import math
 from dynamic_stack_decider.abstract_decision_element import AbstractDecisionElement
-import humanoid_league_msgs.msg
-from bitbots_hcm.hcm_dsd.hcm_blackboard import STATE_ANIMATION_RUNNING, STATE_CONTROLLABLE, STATE_FALLEN, STATE_FALLING, \
-    STATE_HARDWARE_PROBLEM, STATE_MOTOR_OFF, STATE_PENALTY, STATE_PICKED_UP, STATE_RECORD, STATE_SHUT_DOWN, \
-    STATE_STARTUP, STATE_WALKING, STATE_HCM_OFF, STATE_KICKING
+from humanoid_league_msgs.msg import RobotControlState
 from humanoid_league_speaker.speaker import speak
 from humanoid_league_msgs.msg import Audio
 
@@ -16,17 +13,17 @@ class StartHCM(AbstractDecisionElement):
 
     def perform(self, reevaluate=False):
         if self.blackboard.shut_down_request:
-            if self.blackboard.current_state == STATE_HARDWARE_PROBLEM:
-                self.blackboard.current_state = STATE_SHUT_DOWN
+            if self.blackboard.current_state == RobotControlState.HARDWARE_PROBLEM:
+                self.blackboard.current_state = RobotControlState.SHUTDOWN
                 return "SHUTDOWN_WHILE_HARDWARE_PROBLEM"
             else:
-                self.blackboard.current_state = STATE_SHUT_DOWN
+                self.blackboard.current_state = RobotControlState.SHUTDOWN
                 return "SHUTDOWN_REQUESTED"
         else:
             if not reevaluate:
                 if not self.is_walkready():
                     return "NOT_WALKREADY"
-                self.blackboard.current_state = STATE_STARTUP
+                self.blackboard.current_state = RobotControlState.STARTUP
             return "RUNNING"
 
     def is_walkready(self):
@@ -75,7 +72,7 @@ class Record(AbstractDecisionElement):
     def perform(self, reevaluate=False):
         # check if the robot is currently recording animations
         if self.blackboard.record_active:
-            self.blackboard.current_state = STATE_RECORD
+            self.blackboard.current_state = RobotControlState.RECORD
             return "RECORD_ACTIVE"
         else:
             # robot is not recording
@@ -127,22 +124,22 @@ class CheckMotors(AbstractDecisionElement):
                 self.blackboard.motor_off_time) + " seconds. Will shut down the motors and wait for commands.")
             self.publish_debug_data("Time since last motor goals",
                                     self.blackboard.current_time.to_sec() - self.blackboard.last_motor_goal_time.to_sec())
-            self.blackboard.current_state = STATE_MOTOR_OFF
+            self.blackboard.current_state = RobotControlState.MOTOR_OFF
             # we do an action sequence to turn off the motors and stay in motor off
             return "TURN_OFF"
 
         # see if we get no messages or always the exact same
         if self.blackboard.current_time.to_sec() - self.last_different_msg_time.to_sec() > 0.1:
             if self.blackboard.is_power_on:
-                if self.blackboard.current_state == STATE_STARTUP and self.blackboard.current_time.to_sec() - \
-                        self.blackboard.start_time.to_sec() < 10:
+                if (self.blackboard.current_state == RobotControlState.STARTUP and
+                        self.blackboard.current_time.to_sec() - self.blackboard.start_time.to_sec() < 10):
                     # we are still in startup phase, just wait and dont complain
                     return "MOTORS_NOT_STARTED"
                 else:
                     # tell that we have a hardware problem
                     self.had_problem = True
                     # wait for motors to connect
-                    self.blackboard.current_state = STATE_HARDWARE_PROBLEM
+                    self.blackboard.current_state = RobotControlState.HARDWARE_PROBLEM
                     return "PROBLEM"
             else:
                 # we have to turn the motors on
@@ -192,12 +189,12 @@ class CheckIMU(AbstractDecisionElement):
                 return "IMU_NOT_STARTED"
 
         if self.blackboard.current_time.to_sec() - self.last_different_msg_time.to_sec() > 0.1:
-            if self.blackboard.current_state == STATE_STARTUP and self.blackboard.current_time.to_sec() - \
+            if self.blackboard.current_state == RobotControlState.STARTUP and self.blackboard.current_time.to_sec() - \
                     self.blackboard.start_time.to_sec() < 10:
                 # wait for the IMU to start
                 return "IMU_NOT_STARTED"
             else:
-                self.blackboard.current_state = STATE_HARDWARE_PROBLEM
+                self.blackboard.current_state = RobotControlState.HARDWARE_PROBLEM
                 self.had_problem = True
                 return "PROBLEM"
 
@@ -235,13 +232,13 @@ class CheckPressureSensor(AbstractDecisionElement):
             self.last_different_msg_time = self.blackboard.current_time
 
         if self.blackboard.current_time.to_sec() - self.last_different_msg_time.to_sec() > 0.1:
-            if self.blackboard.current_state == STATE_STARTUP and self.blackboard.current_time.to_sec() - \
+            if self.blackboard.current_state == RobotControlState.STARTUP and self.blackboard.current_time.to_sec() - \
                     self.blackboard.start_time.to_sec() < 10:
                 # wait for the pressure sensors to start
-                self.blackboard.current_state = STATE_STARTUP
+                self.blackboard.current_state = RobotControlState.STARTUP
                 return "PRESSURE_NOT_STARTED"
             else:
-                self.blackboard.current_state = STATE_HARDWARE_PROBLEM
+                self.blackboard.current_state = RobotControlState.HARDWARE_PROBLEM
                 return "PROBLEM"
 
         if self.had_problem:
@@ -269,7 +266,7 @@ class PickedUp(AbstractDecisionElement):
                 sum(self.blackboard.pressures) < 10 and \
                 abs(self.blackboard.smooth_accel[0]) < self.blackboard.pickup_accel_threshold and \
                 abs(self.blackboard.smooth_accel[1]) < self.blackboard.pickup_accel_threshold:
-            self.blackboard.current_state = STATE_PICKED_UP
+            self.blackboard.current_state = RobotControlState.PICKED_UP
             if not reevaluate:
                 speak("Picked up!", self.blackboard.speak_publisher, priority=50)
             # we do an action sequence to go to walkready and stay in picked up state
@@ -291,7 +288,7 @@ class Falling(AbstractDecisionElement):
         # check if the robot is currently falling
         falling_direction = self.blackboard.fall_checker.check_falling(self.blackboard.gyro, self.blackboard.quaternion)
         if self.blackboard.falling_detection_active and falling_direction is not None:
-            self.blackboard.current_state = STATE_FALLING
+            self.blackboard.current_state = RobotControlState.FALLING
 
             if falling_direction == self.blackboard.fall_checker.FRONT:
                 return "FALLING_FRONT"
@@ -372,7 +369,7 @@ class Fallen(AbstractDecisionElement):
         # check if the robot is currently laying on the ground
         fallen_side = self.blackboard.fall_checker.check_fallen(self.blackboard.quaternion, self.blackboard.gyro)
         if self.blackboard.is_stand_up_active and fallen_side is not None:
-            self.blackboard.current_state = STATE_FALLEN
+            self.blackboard.current_state = RobotControlState.FALLEN
             # we play a stand up animation
             if fallen_side == self.blackboard.fall_checker.FRONT:
                 return "FALLEN_FRONT"
@@ -397,7 +394,7 @@ class ExternalAnimation(AbstractDecisionElement):
 
     def perform(self, reevaluate=False):
         if self.blackboard.external_animation_running:
-            self.blackboard.current_state = STATE_ANIMATION_RUNNING
+            self.blackboard.current_state = RobotControlState.ANIMATION_RUNNING
             return "ANIMATION_RUNNING"
         else:
             return "FREE"
@@ -413,7 +410,7 @@ class Walking(AbstractDecisionElement):
 
     def perform(self, reevaluate=False):
         if self.blackboard.current_time.to_sec() - self.blackboard.last_walking_goal_time.to_sec() < 0.1:
-            self.blackboard.current_state = STATE_WALKING
+            self.blackboard.current_state = RobotControlState.WALKING
             if self.blackboard.animation_requested:
                 self.blackboard.animation_requested = False
                 # we are walking but we have to stop to play an animation
@@ -436,7 +433,7 @@ class Kicking(AbstractDecisionElement):
     def perform(self, reevaluate=False):
         if self.blackboard.last_kick_feedback is not None and \
                 (rospy.Time.now() - self.blackboard.last_kick_feedback) < rospy.Duration.from_sec(1):
-            self.blackboard.current_state = STATE_KICKING
+            self.blackboard.current_state = RobotControlState.KICKING
             return 'KICKING'
         else:
             return 'NOT_KICKING'

--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/hcm_blackboard.py
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/hcm_blackboard.py
@@ -15,29 +15,10 @@ from humanoid_league_msgs.msg import RobotControlState
 from bitbots_hcm.fall_classifier import FallClassifier
 import rospkg
 
-# robot states that are published to the rest of the software
-# definition from humanoid_league_msgs/RobotControlState.msg
-STATE_CONTROLLABLE = 0
-STATE_FALLING = 1
-STATE_FALLEN = 2
-STATE_GETTING_UP = 3
-STATE_ANIMATION_RUNNING = 4
-STATE_STARTUP = 5
-STATE_SHUT_DOWN = 6
-STATE_PENALTY = 7
-STATE_PENALTY_ANIMATION = 8
-STATE_RECORD = 9
-STATE_WALKING = 10
-STATE_MOTOR_OFF = 11
-STATE_HCM_OFF = 12
-STATE_HARDWARE_PROBLEM = 13
-STATE_PICKED_UP = 14
-STATE_KICKING = 15
-
 
 class HcmBlackboard():
     def __init__(self):
-        self.current_state = STATE_STARTUP
+        self.current_state = RobotControlState.STARTUP
         self.stopped = False
         self.shut_down_request = False
         self.simulation_active = rospy.get_param("/simulation_active", False)

--- a/bitbots_hcm/src/bitbots_hcm/humanoid_control_module.py
+++ b/bitbots_hcm/src/bitbots_hcm/humanoid_control_module.py
@@ -19,8 +19,6 @@ from humanoid_league_speaker.speaker import speak
 from bitbots_msgs.msg import FootPressure, DynUpAction, KickAction
 
 from bitbots_msgs.msg import JointCommand
-from bitbots_hcm.hcm_dsd.hcm_blackboard import STATE_CONTROLLABLE, STATE_WALKING, STATE_ANIMATION_RUNNING, \
-    STATE_SHUT_DOWN, STATE_HCM_OFF, STATE_FALLEN, STATE_KICKING, STATE_GETTING_UP, STATE_STARTUP
 from bitbots_hcm.cfg import hcm_paramsConfig
 from bitbots_hcm.hcm_dsd.hcm_blackboard import HcmBlackboard
 from dynamic_stack_decider.dsd import DSD
@@ -129,15 +127,17 @@ class HardwareControlManager:
 
     def walking_goal_callback(self, msg):
         self.blackboard.last_walking_goal_time = rospy.Time.now()
-        if self.blackboard.current_state in [STATE_CONTROLLABLE, STATE_WALKING]:
+        if self.blackboard.current_state in [RobotControlState.CONTROLLABLE, RobotControlState.WALKING]:
             self.joint_goal_publisher.publish(msg)
 
     def dynup_callback(self, msg):
-        if self.blackboard.current_state in [STATE_STARTUP, STATE_FALLEN, STATE_GETTING_UP]:
+        if self.blackboard.current_state in [RobotControlState.STARTUP,
+                                             RobotControlState.FALLEN,
+                                             RobotControlState.GETTING_UP]:
             self.joint_goal_publisher.publish(msg)
 
     def head_goal_callback(self, msg):
-        if self.blackboard.current_state in [STATE_CONTROLLABLE, STATE_WALKING]:
+        if self.blackboard.current_state in [RobotControlState.CONTROLLABLE, RobotControlState.WALKING]:
             # we can move our head
             self.joint_goal_publisher.publish(msg)
 
@@ -150,7 +150,7 @@ class HardwareControlManager:
             self.joint_goal_publisher.publish(msg)
 
     def kick_goal_callback(self, msg):
-        if self.blackboard.current_state == STATE_KICKING:
+        if self.blackboard.current_state == RobotControlState.KICKING:
             # we can perform a kick
             self.joint_goal_publisher.publish(msg)
 
@@ -173,7 +173,7 @@ class HardwareControlManager:
             else:
                 # comming from outside
                 # check if we can run an animation now
-                if self.blackboard.current_state != STATE_CONTROLLABLE:
+                if self.blackboard.current_state != RobotControlState.CONTROLLABLE:
                     rospy.logwarn("HCM is not controllable, animation refused.")
                     return
                 else:
@@ -260,7 +260,7 @@ class HardwareControlManager:
         rospy.logwarn("You're stopping the HCM. The robot will sit down and power off its motors.")
         speak("Stopping HCM", self.blackboard.speak_publisher, priority=50)
         # now wait for it finishing the shutdown procedure
-        while not self.blackboard.current_state == STATE_HCM_OFF:
+        while not self.blackboard.current_state == RobotControlState.HCM_OFF:
             # we still have to update everything
             self.blackboard.current_time = rospy.Time.now()
             self.dsd.update()

--- a/bitbots_hcm/src/bitbots_hcm/humanoid_control_module.py
+++ b/bitbots_hcm/src/bitbots_hcm/humanoid_control_module.py
@@ -167,11 +167,11 @@ class HardwareControlManager:
 
         if msg.first:
             if msg.hcm:
-                # comming from ourselves
+                # coming from ourselves
                 # we don't have to do anything, since we must be in the right state
                 pass
             else:
-                # comming from outside
+                # coming from outside
                 # check if we can run an animation now
                 if self.blackboard.current_state != RobotControlState.CONTROLLABLE:
                     rospy.logwarn("HCM is not controllable, animation refused.")
@@ -186,7 +186,7 @@ class HardwareControlManager:
                 self.blackboard.hcm_animation_finished = True
                 pass
             else:
-                # this is the last frame, we want to tell the DSD, that we're finished with the animations
+                # this is the last frame, we want to tell the DSD that we're finished with the animations
                 self.blackboard.external_animation_running = False
                 if msg.position is None:
                     # probably this was just to tell us we're finished
@@ -205,7 +205,7 @@ class HardwareControlManager:
             if msg.position.points[0].effort:
                 out_msg.max_currents = [-x for x in msg.position.points[0].effort]
             if self.blackboard.shut_down_request:
-                # there are sometimes transmittions errors during shutdown due to race conditions
+                # there are sometimes transmission errors during shutdown due to race conditions
                 # there is nothing we can do so just ignore the errors in this case
                 try:
                     self.joint_goal_publisher.publish(out_msg)


### PR DESCRIPTION
## Proposed changes
Currently, the robot states from humanoid_league_msgs/RobotControlState are redefined in the HCM. This might lead to problems when the message is changed. With this PR, the HCM uses the definitions from the message directly.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

