### PR TITLE
Deactivate shutdown hook for sitdown in simulation

### DIFF
--- a/bitbots_animation_server/src/bitbots_animation_server/animation_node.py
+++ b/bitbots_animation_server/src/bitbots_animation_server/animation_node.py
@@ -25,7 +25,8 @@ class AnimationNode:
         # currently we set log level to info since the action server is spamming too much
         log_level = rospy.INFO if rospy.get_param("debug_active", False) else rospy.INFO
         rospy.init_node("animation", log_level=log_level, anonymous=False)
-        rospy.on_shutdown(self.on_shutdown_hook)
+        if not rospy.get_param("simulation_active"):
+            rospy.on_shutdown(self.on_shutdown_hook)
         rospy.logdebug("Starting Animation Server")
         server = PlayAnimationAction(rospy.get_name())
         rospy.spin()

--- a/bitbots_hcm/src/bitbots_hcm/humanoid_control_module.py
+++ b/bitbots_hcm/src/bitbots_hcm/humanoid_control_module.py
@@ -36,7 +36,8 @@ class HardwareControlManager:
         rospy.init_node('bitbots_hcm', log_level=log_level, anonymous=False)
         rospy.sleep(0.1)  # Otherwise messages will get lost, bc the init is not finished
         rospy.loginfo("Starting hcm")
-        rospy.on_shutdown(self.on_shutdown_hook)
+        if not rospy.get_param("simulation_active"):
+            rospy.on_shutdown(self.on_shutdown_hook)
 
         # stack machine
         self.blackboard = HcmBlackboard()


### PR DESCRIPTION
## Proposed changes
This deactivates the shutdown hook that lets the robot sit down in the animation server and the hcm when the simulation is active. In simulation, this feature is not needed because no harm to the motors is done on shutdown. Deactivating it leads to a significantly more pleasant debugging experience, because you don't have to wait after pressing Ctrl-C.

## Necessary checks
- [ ] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

