### PR TITLE
remove waits in HCM

### DIFF
--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/hcm.dsd
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/hcm.dsd
@@ -31,10 +31,10 @@ $StartHCM
                                 FALLEN_RIGHT --> @CancelGoals, @PlayAnimationStandUpRight, @PlayAnimationDynup + direction:back
                                 FALLEN_LEFT --> @CancelGoals, @PlayAnimationStandUpLeft, @PlayAnimationDynup + direction:back
                                 NOT_FALLEN --> $Falling
-                                    FALLING_LEFT --> @CancelGoals, @PlayAnimationFallingLeft, @WaitNoReevaluate + time:1
-                                    FALLING_RIGHT --> @CancelGoals, @PlayAnimationFallingRight, @WaitNoReevaluate + time:1
-                                    FALLING_FRONT --> @CancelGoals, @PlayAnimationFallingFront, @WaitNoReevaluate + time:1
-                                    FALLING_BACK --> @CancelGoals, @PlayAnimationFallingBack, @WaitNoReevaluate + time:1
+                                    FALLING_LEFT --> @CancelGoals, @PlayAnimationFallingLeft
+                                    FALLING_RIGHT --> @CancelGoals, @PlayAnimationFallingRight
+                                    FALLING_FRONT --> @CancelGoals, @PlayAnimationFallingFront
+                                    FALLING_BACK --> @CancelGoals, @PlayAnimationFallingBack
                                     NOT_FALLING --> $Sitting
                                         YES --> @PlayAnimationDynup + direction:rise
                                         NO --> $ExternalAnimation


### PR DESCRIPTION
## Proposed changes
Optimizes HCM for https://github.com/bit-bots/bitbots_motion/issues/248
Removes waits which are unnecessary in simulation and maybe also in real robot by now (since Dynup can handle better some movement in the beginning)

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

