### PR TITLE
dynup: make head go to zero

### DIFF
--- a/bitbots_dynup/include/bitbots_dynup/dynup_engine.h
+++ b/bitbots_dynup/include/bitbots_dynup/dynup_engine.h
@@ -41,6 +41,8 @@ class DynupEngine : public bitbots_splines::AbstractEngine<DynupRequest, DynupRe
 
   bool isStabilizingNeeded() const;
 
+  bool isHeadZero() const;
+
   bitbots_splines::PoseSpline getRFootSplines() const;
 
   bitbots_splines::PoseSpline getLHandSplines() const;

--- a/bitbots_dynup/include/bitbots_dynup/dynup_utils.h
+++ b/bitbots_dynup/include/bitbots_dynup/dynup_utils.h
@@ -9,6 +9,7 @@ struct DynupResponse {
   tf2::Transform l_hand_goal_pose;
   tf2::Transform r_hand_goal_pose;
   bool is_stabilizing_needed;
+  bool is_head_zero;
 };
 
 struct DynupRequest {

--- a/bitbots_dynup/src/dynup_engine.cpp
+++ b/bitbots_dynup/src/dynup_engine.cpp
@@ -164,6 +164,7 @@ DynupResponse DynupEngine::update(double dt) {
   goals_.l_hand_goal_pose = offset_left_ * l_hand_pose;
   goals_.r_hand_goal_pose = offset_right_ * r_hand_pose;
   goals_.is_stabilizing_needed = isStabilizingNeeded();
+  goals_.is_head_zero = isHeadZero();
 
   publishDebug();
 
@@ -676,6 +677,26 @@ bool DynupEngine::isStabilizingNeeded() const {
                                         params_.time_foot_ground_back +
                                         params_.time_full_squat_hands +
                                         params_.time_full_squat_legs) ||
+           (direction_ == 2) || (direction_ == 3));
+}
+
+bool DynupEngine::isHeadZero() const{
+    // set heads zero in the middle of rise phase
+    return ((direction_ == 1 && time_ >= params_.time_hands_side +
+                                        params_.time_hands_rotate +
+                                        params_.time_foot_close +
+                                        params_.time_hands_front +
+                                        params_.time_foot_ground_front +
+                                        params_.time_torso_45 +
+                                        params_.time_to_squat +
+                                        params_.wait_in_squat_front +
+                                        0.5*params_.rise_time) ||
+           (direction_ == 0 && time_ >= params_.time_legs_close +
+                                        params_.time_foot_ground_back +
+                                        params_.time_full_squat_hands +
+                                        params_.time_full_squat_legs +
+                                        params_.wait_in_squat_back+
+                                        0.5*params_.rise_time) ||
            (direction_ == 2) || (direction_ == 3));
 }
 

--- a/bitbots_dynup/src/dynup_ik.cpp
+++ b/bitbots_dynup/src/dynup_ik.cpp
@@ -29,7 +29,7 @@ bitbots_splines::JointGoals DynupIK::calculate(const DynupResponse &ik_goals) {
   ik_options.return_approximate_solution = true;
 
   geometry_msgs::Pose right_foot_goal_msg, left_foot_goal_msg, right_hand_goal_msg, left_hand_goal_msg;
-  
+
   tf2::toMsg(ik_goals.r_foot_goal_pose, right_foot_goal_msg);
   tf2::toMsg(ik_goals.l_foot_goal_pose, left_foot_goal_msg);
   tf2::toMsg(ik_goals.r_hand_goal_pose, right_hand_goal_msg);
@@ -78,24 +78,28 @@ bitbots_splines::JointGoals DynupIK::calculate(const DynupResponse &ik_goals) {
     bitbots_splines::JointGoals result;
     result.first = joint_names;
     result.second = joint_goals;
-    /* sets head motor positions to 0, as the IK will return random values for those unconstrained motors. */
+    /* sets head motors to correct positions, as the IK will return random values for those unconstrained motors. */
     for(int i = 0; i  < result.first.size(); i++)
     {
         if(result.first[i] == "HeadPan") {
             result.second[i] = 0;
         }
         else if(result.first[i] ==  "HeadTilt") {
-            if (direction_ == "front")
-            {
-                result.second[i] = 0.785398;
-            }
-            else if (direction_ == "back")
-            {
-                result.second[i] = -0.785398;
-            }
-            else
-            {
+            if (ik_goals.is_head_zero){
                 result.second[i] = 0;
+            }else{
+                if (direction_ == "front")
+                {
+                    result.second[i] = 1.0;
+                }
+                else if (direction_ == "back")
+                {
+                    result.second[i] = -1.5;
+                }
+                else
+                {
+                    result.second[i] = 0;
+                }
             }
         }
     }

--- a/bitbots_dynup/src/dynup_stabilizer.cpp
+++ b/bitbots_dynup/src/dynup_stabilizer.cpp
@@ -71,6 +71,7 @@ DynupResponse Stabilizer::stabilize(const DynupResponse &ik_goals, const ros::Du
     response.l_foot_goal_pose = left_foot_goal;
     response.r_hand_goal_pose = right_hand_goal;
     response.l_hand_goal_pose = left_hand_goal;
+    response.is_head_zero = ik_goals.is_head_zero;
 
     return response;
 }


### PR DESCRIPTION
## Proposed changes
Fixes https://github.com/bit-bots/bitbots_motion/issues/250
Also changes the head position during stand up to be more extreme. I think this will help pushing the CoM a bit more into the right direction.

https://user-images.githubusercontent.com/11520148/119804865-0b36ec80-bee1-11eb-8751-ff20c176ddd3.mp4



## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

