### PR TITLE
Fix GETTING_UP state in initial state

### DIFF
--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/actions/play_animation.py
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/actions/play_animation.py
@@ -161,7 +161,12 @@ class PlayAnimationDynup(AbstractActionElement):
         super(PlayAnimationDynup, self).__init__(blackboard, dsd, parameters=None)
         self.direction = parameters.get('direction')
         self.first_perform = True
-        self.blackboard.current_state = RobotControlState.GETTING_UP
+
+        # A parameter 'initial' is passed when dynup is called during the startup phase,
+        # in this case we do not want to set the state to GETTING_UP.
+        initial = parameters.get('initial', False)
+        if not initial:
+            self.blackboard.current_state = RobotControlState.GETTING_UP
 
     def perform(self, reevaluate=False):
         # deactivate falling since it will be wrongly detected

--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/hcm.dsd
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/hcm.dsd
@@ -5,7 +5,7 @@ $PickedUp
 
 -->HCM
 $StartHCM
-    NOT_WALKREADY --> @PlayAnimationDynup + direction:rise
+    NOT_WALKREADY --> @PlayAnimationDynup + direction:rise + initial:true
     SHUTDOWN_REQUESTED --> #ShutDownProcedure
     SHUTDOWN_WHILE_HARDWARE_PROBLEM --> @StayShutDown
     RUNNING --> $Stop


### PR DESCRIPTION
## Proposed changes
The robot state was set to `GETTING_UP` when dynup is used to set the position to walkready. This is wrong and confuses the localization. Instead, the state should not be set in this case and remain `STARTUP`.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

