### PR TITLE
Use -Wall in motion cpp packages

### DIFF
--- a/bitbots_dynamic_kick/CMakeLists.txt
+++ b/bitbots_dynamic_kick/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(bitbots_dynamic_kick)
 set(CMAKE_CXX_STANDARD 17)
+add_compile_options(-Wall -Werror -Wno-unused)
 
 ## Find catkin macros and libraries
 find_package(catkin REQUIRED COMPONENTS

--- a/bitbots_dynamic_kick/src/kick_ik.cpp
+++ b/bitbots_dynamic_kick/src/kick_ik.cpp
@@ -22,7 +22,7 @@ void KickIK::reset() {
    * first step will be not correct */
   std::vector<std::string> names_vec = {"LHipPitch", "LKnee", "LAnklePitch", "RHipPitch", "RKnee", "RAnklePitch"};
   std::vector<double> pos_vec = {0.7, 1.0, -0.4, -0.7, -1.0, 0.4};
-  for (int i = 0; i < names_vec.size(); ++i) {
+  for (size_t i = 0; i < names_vec.size(); ++i) {
     goal_state_->setJointPositions(names_vec[i], &pos_vec[i]);
   }
 }

--- a/bitbots_dynamic_kick/src/kick_node.cpp
+++ b/bitbots_dynamic_kick/src/kick_node.cpp
@@ -4,8 +4,8 @@ namespace bitbots_dynamic_kick {
 
 KickNode::KickNode(const std::string &ns) :
     server_(node_handle_, "dynamic_kick", boost::bind(&KickNode::executeCb, this, _1), false),
-    listener_(tf_buffer_),
     visualizer_(ns + "debug/dynamic_kick"),
+    listener_(tf_buffer_),
     robot_model_loader_(ns + "robot_description", false) {
   ros::NodeHandle pnh("~");
   pnh.param<std::string>("base_link_frame", base_link_frame_, "base_link");
@@ -52,7 +52,7 @@ void KickNode::copRCallback(const geometry_msgs::PointStamped &cop) {
 }
 
 void KickNode::jointStateCallback(const sensor_msgs::JointState &joint_states) {
-  for (int i = 0; i < joint_states.name.size(); ++i) {
+  for (size_t i = 0; i < joint_states.name.size(); ++i) {
     current_state_->setJointPositions(joint_states.name[i], &joint_states.position[i]);
   }
 }
@@ -224,7 +224,7 @@ bitbots_splines::JointGoals KickNode::kickStep(double dt) {
   bitbots_splines::JointGoals motor_goals = ik_.calculate(stabilized_positions);
 
   /* visualization of the values calculated above */
-  for (int i = 0; i < motor_goals.first.size(); ++i) {
+  for (size_t i = 0; i < motor_goals.first.size(); ++i) {
     goal_state_->setJointPositions(motor_goals.first[i], &motor_goals.second[i]);
   }
   visualizer_.publishGoals(positions, stabilized_positions, goal_state_, engine_.getPhase());

--- a/bitbots_dynup/CMakeLists.txt
+++ b/bitbots_dynup/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(bitbots_dynup)
 set(CMAKE_CXX_STANDARD 17)
+add_compile_options(-Wall -Werror -Wno-unused)
 
 ## Find catkin macros and libraries
 find_package(catkin REQUIRED COMPONENTS

--- a/bitbots_dynup/src/dynup_ik.cpp
+++ b/bitbots_dynup/src/dynup_ik.cpp
@@ -13,7 +13,7 @@ void DynupIK::init(moveit::core::RobotModelPtr kinematic_model) {
 }
 
 void DynupIK::reset() {
-  for (int i = 0; i < current_joint_states_.name.size(); i++) {
+  for (size_t i = 0; i < current_joint_states_.name.size(); i++) {
     goal_state_->setJointPositions(current_joint_states_.name[i], &current_joint_states_.position[i]);
   }
 }
@@ -78,7 +78,7 @@ bitbots_splines::JointGoals DynupIK::calculate(const DynupResponse &ik_goals) {
     result.first = joint_names;
     result.second = joint_goals;
     /* sets head motors to correct positions, as the IK will return random values for those unconstrained motors. */
-    for (int i = 0; i < result.first.size(); i++) {
+    for (size_t i = 0; i < result.first.size(); i++) {
       if (result.first[i] == "HeadPan") {
         result.second[i] = 0;
       } else if (result.first[i] == "HeadTilt") {

--- a/bitbots_dynup/src/dynup_node.cpp
+++ b/bitbots_dynup/src/dynup_node.cpp
@@ -5,8 +5,8 @@ namespace bitbots_dynup {
 DynUpNode::DynUpNode() :
     server_(node_handle_, "dynup", boost::bind(&DynUpNode::executeCb, this, _1), false),
     visualizer_("debug/dynup"),
-    robot_model_loader_("robot_description", false),
-    listener_(tf_buffer_) {
+    listener_(tf_buffer_),
+    robot_model_loader_("robot_description", false) {
   ros::NodeHandle pnh("~");
   pnh.param<std::string>("base_link_frame", base_link_frame_, "base_link");
   pnh.param<std::string>("r_sole_frame", r_sole_frame_, "r_sole");

--- a/bitbots_dynup/src/dynup_stabilizer.cpp
+++ b/bitbots_dynup/src/dynup_stabilizer.cpp
@@ -1,7 +1,5 @@
 #include "bitbots_dynup/dynup_stabilizer.h"
 
-#include <bitbots_splines/dynamic_balancing_goal.h>
-
 namespace bitbots_dynup {
 
 void Stabilizer::init(moveit::core::RobotModelPtr kinematic_model) {

--- a/bitbots_moveit_bindings/CMakeLists.txt
+++ b/bitbots_moveit_bindings/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(bitbots_moveit_bindings)
+add_compile_options(-Wall -Werror -Wno-unused)
 
 find_package(catkin REQUIRED COMPONENTS
     moveit_core

--- a/bitbots_moveit_bindings/src/bitbots_moveit_bindings.cpp
+++ b/bitbots_moveit_bindings/src/bitbots_moveit_bindings.cpp
@@ -170,7 +170,7 @@ moveit::py_bindings_tools::ByteString getPositionFK(const std::string& request_s
 
   static moveit::core::RobotState robot_state(robot_model);
   sensor_msgs::JointState joint_state = request.robot_state.joint_state;
-  for (int i = 0; i < joint_state.name.size(); ++i) {
+  for (size_t i = 0; i < joint_state.name.size(); ++i) {
     robot_state.setJointPositions(joint_state.name[i], &joint_state.position[i]);
   }
   robot_state.update();

--- a/bitbots_odometry/CMakeLists.txt
+++ b/bitbots_odometry/CMakeLists.txt
@@ -3,6 +3,7 @@ project(bitbots_odometry)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
 # add_compile_options(-std=c++11)
+add_compile_options(-Wall -Werror -Wno-unused)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/bitbots_odometry/src/motion_odometry.cpp
+++ b/bitbots_odometry/src/motion_odometry.cpp
@@ -22,7 +22,6 @@ MotionOdometry::MotionOdometry() {
   ros::Subscriber odom_subscriber = n.subscribe("walk_engine_odometry", 1, &MotionOdometry::odomCallback, this);
 
   ros::Publisher pub_odometry = n.advertise<nav_msgs::Odometry>("motion_odometry", 1);
-  odometry_to_support_foot_ = tf2::Transform();
   // set the origin to 0. will be set correctly on recieving first support state
   odometry_to_support_foot_.setOrigin({0, 0, 0});
   odometry_to_support_foot_.setRotation(tf2::Quaternion(0, 0, 0, 1));
@@ -152,7 +151,7 @@ void MotionOdometry::supportCallback(const bitbots_msgs::SupportState msg) {
                 base_to_current_support_msg = tf_buffer_.lookupTransform(base_link_frame_, current_support_link, ros::Time(0), ros::Duration(10.0));
         odometry_to_support_foot_.setOrigin({-1 * base_to_current_support_msg.transform.translation.x,
                                             -1 * base_to_current_support_msg.transform.translation.y, 0});
-    }catch (tf2::TransformException ex){
+    }catch (tf2::TransformException &ex){
         ROS_WARN("Could not initialize motion odometry correctly, since there were no transforms available fast enough on startup. Will initialize with 0,0,0");
     }
   }

--- a/bitbots_odometry/src/odometry_fuser.cpp
+++ b/bitbots_odometry/src/odometry_fuser.cpp
@@ -101,7 +101,7 @@ OdometryFuser::OdometryFuser() : tf_listener_(tf_buffer_), support_state_cache_(
       geometry_msgs::TransformStamped imu_mounting_transform = tf_buffer_.lookupTransform(
         base_link_frame_, imu_frame_, fused_time_);
       fromMsg(imu_mounting_transform.transform, imu_mounting_offset);
-    } catch (tf2::TransformException ex) {
+    } catch (tf2::TransformException &ex) {
       ROS_ERROR("Not able to use the IMU%s", ex.what());
     }
 
@@ -202,7 +202,7 @@ tf2::Transform OdometryFuser::getCurrentRotationPoint() {
       rotation_point = tf_buffer_.lookupTransform(base_link_frame_, support_frame,
                                                   fused_time_);
       fromMsg(rotation_point.transform, rotation_point_tf);
-    } catch (tf2::TransformException ex) {
+    } catch (tf2::TransformException &ex) {
       ROS_ERROR("%s", ex.what());
     }
   } else if (current_support_state == bitbots_msgs::SupportState::DOUBLE) {

--- a/bitbots_quintic_walk/CMakeLists.txt
+++ b/bitbots_quintic_walk/CMakeLists.txt
@@ -4,6 +4,7 @@ project(bitbots_quintic_walk)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_CXX_STANDARD 17)
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+add_compile_options(-Wall -Werror -Wno-unused)
 
 set(SOURCES
         src/walk_visualizer.cpp

--- a/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_ik.h
+++ b/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_ik.h
@@ -3,7 +3,6 @@
 #include "bitbots_quintic_walk/walk_utils.h"
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <moveit/robot_state/robot_state.h>
-#include "bitbots_splines/reference_goals.h"
 #include "bitbots_splines/abstract_ik.h"
 namespace bitbots_quintic_walk {
 

--- a/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_stabilizer.h
+++ b/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_stabilizer.h
@@ -7,8 +7,6 @@
 #include <control_toolbox/pid.h>
 #include <bitbots_splines/abstract_stabilizer.h>
 #include "bitbots_quintic_walk/walk_utils.h"
-#include "bitbots_splines/dynamic_balancing_goal.h"
-#include "bitbots_splines/reference_goals.h"
 #include <rot_conv/rot_conv.h>
 #include <Eigen/Geometry>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/bitbots_quintic_walk/src/walk_engine.cpp
+++ b/bitbots_quintic_walk/src/walk_engine.cpp
@@ -8,16 +8,16 @@ https://github.com/Rhoban/model/
 namespace bitbots_quintic_walk {
 
 WalkEngine::WalkEngine(const std::string ns) :
+    engine_state_(WalkState::IDLE),
     phase_(0.0),
     last_phase_(0.0),
-    pause_requested_(false),
-    left_kick_requested_(false),
-    right_kick_requested_(false),
     time_paused_(0.0),
     pause_duration_(0.0),
+    pause_requested_(false),
     phase_rest_active_(false),
+    left_kick_requested_(false),
+    right_kick_requested_(false),
     is_left_support_foot_(false),
-    engine_state_(WalkState::IDLE),
     foot_pos_vel_at_foot_change_({0.0, 0.0, 0.0}),
     foot_pos_acc_at_foot_change_({0.0, 0.0, 0.0}),
     foot_orientation_pos_at_last_foot_change_({0, 0, 0}),

--- a/bitbots_quintic_walk/src/walk_ik.cpp
+++ b/bitbots_quintic_walk/src/walk_ik.cpp
@@ -66,7 +66,7 @@ void WalkIK::reset() {
   // based method. Otherwise, the first step will be not correct
   std::vector<std::string> names_vec = {"LHipPitch", "LKnee", "LAnklePitch", "RHipPitch", "RKnee", "RAnklePitch"};
   std::vector<double> pos_vec = {0.7, 1.0, -0.4, -0.7, -1.0, 0.4};
-  for (long i = 0; i < names_vec.size(); i++) {
+  for (size_t i = 0; i < names_vec.size(); i++) {
     // besides its name, this method only changes a single joint position...
     goal_state_->setJointPositions(names_vec[i], &pos_vec[i]);
   }

--- a/bitbots_quintic_walk/src/walk_node.cpp
+++ b/bitbots_quintic_walk/src/walk_node.cpp
@@ -8,9 +8,9 @@
 namespace bitbots_quintic_walk {
 
 WalkNode::WalkNode(const std::string ns) :
+    walk_engine_(ns),
     robot_model_loader_(ns + "robot_description", false),
-    stabilizer_(ns),
-    walk_engine_(ns) {
+    stabilizer_(ns) {
   nh_ = ros::NodeHandle(ns);
   pnh_ = ros::NodeHandle("~");
 
@@ -384,7 +384,7 @@ void WalkNode::robotStateCb(const humanoid_league_msgs::RobotControlState msg) {
 void WalkNode::jointStateCb(const sensor_msgs::JointState &msg) {
   std::vector<std::string> names = msg.name;
   std::vector<double> goals = msg.position;
-  for (int i = 0; i < names.size(); i++) {
+  for (size_t i = 0; i < names.size(); i++) {
     // besides its name, this method only changes a single joint position...
     current_state_->setJointPositions(names[i], &goals[i]);
   }
@@ -395,7 +395,7 @@ void WalkNode::jointStateCb(const sensor_msgs::JointState &msg) {
     double effort_sum = 0;
     const std::vector<std::string>
         &fly_joint_names = (walk_engine_.isLeftSupport()) ? ik_.getRightLegJointNames() : ik_.getLeftLegJointNames();
-    for (int i = 0; i < names.size(); i++) {
+    for (size_t i = 0; i < names.size(); i++) {
       // add effort on this joint to sum, if it is part of the flying leg
       if (std::find(fly_joint_names.begin(), fly_joint_names.end(), names[i]) != fly_joint_names.end()) {
         effort_sum = effort_sum + abs(msg.effort[i]);

--- a/bitbots_quintic_walk/src/walk_pywrapper.cpp
+++ b/bitbots_quintic_walk/src/walk_pywrapper.cpp
@@ -95,6 +95,7 @@ void PyWalkWrapper::special_reset(int state, double phase, const std::string cmd
     walk_state = bitbots_quintic_walk::WalkState::KICK;
   } else {
     ROS_WARN("state in special reset not clear");
+    return;
   }
   walk_node_->reset(walk_state, phase, from_python<geometry_msgs::Twist>(cmd_vel), reset_odometry);
 }

--- a/bitbots_quintic_walk/src/walk_visualizer.cpp
+++ b/bitbots_quintic_walk/src/walk_visualizer.cpp
@@ -183,7 +183,7 @@ void WalkVisualizer::publishIKDebug(WalkResponse response,
   goal_state.reset(new robot_state::RobotState(kinematic_model_));
   std::vector<std::string> names = joint_goals.first;
   std::vector<double> goals = joint_goals.second;
-  for (int i = 0; i < names.size(); i++) {
+  for (size_t i = 0; i < names.size(); i++) {
     // besides its name, this method only changes a single joint position...
     goal_state->setJointPositions(names[i], &goals[i]);
   }

--- a/bitbots_splines/CMakeLists.txt
+++ b/bitbots_splines/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(bitbots_splines)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+add_compile_options(-Wall -Werror -Wno-unused)
 
 find_package(catkin REQUIRED COMPONENTS
         roscpp

--- a/bitbots_splines/include/bitbots_splines/abstract_ik.h
+++ b/bitbots_splines/include/bitbots_splines/abstract_ik.h
@@ -27,8 +27,8 @@ namespace bitbots_splines {
             ROS_ERROR("joint_goals_update() called with unequal argument sizes");
         }
 
-        for (int i = 0; i < goals.first.size(); ++i) {
-            for (int j = 0; j < names.size() && j < values.size(); ++j) {
+        for (size_t i = 0; i < goals.first.size(); ++i) {
+            for (size_t j = 0; j < names.size() && j < values.size(); ++j) {
                 if (result.first.at(i) == names.at(j)) {
                     result.second.at(i) = values.at(j);
                 }
@@ -55,8 +55,8 @@ namespace bitbots_splines {
             ROS_ERROR("joint_goals_update() called with unequal argument sizes");
         }
 
-        for (int i = 0; i < goals.first.size(); ++i) {
-            for (int j = 0; j < names.size() && j < diffs.size(); ++j) {
+        for (size_t i = 0; i < goals.first.size(); ++i) {
+            for (size_t j = 0; j < names.size() && j < diffs.size(); ++j) {
                 if (result.first.at(i) == names.at(j)) {
                     result.second.at(i) += diffs.at(j);
                 }

--- a/bitbots_splines/include/bitbots_splines/reference_goals.h
+++ b/bitbots_splines/include/bitbots_splines/reference_goals.h
@@ -10,7 +10,7 @@ class ReferenceLinkGoalBase : public bio_ik::Goal {
   std::string reference_link_name_;
  public:
   ReferenceLinkGoalBase()
-      : link_name_(""), reference_link_name_(""), Goal() {}
+      : Goal(), link_name_(""), reference_link_name_("") {}
   ReferenceLinkGoalBase(const std::string &link_name, const std::string &reference_link_name, double weight = 1.0)
       : link_name_(link_name), reference_link_name_(reference_link_name) {
     weight_ = weight;
@@ -33,7 +33,7 @@ class ReferenceOrientationGoal : public ReferenceLinkGoalBase {
 
  public:
   ReferenceOrientationGoal()
-      : orientation_(0, 0, 0, 1), ReferenceLinkGoalBase() {}
+      : ReferenceLinkGoalBase(), orientation_(0, 0, 0, 1) {}
   ReferenceOrientationGoal(const std::string &link_name, const std::string &reference_link_name,
                            const tf2::Quaternion &orientation, double weight = 1.0)
       : ReferenceLinkGoalBase(link_name, reference_link_name, weight), orientation_(orientation.normalized()) {}


### PR DESCRIPTION
## Proposed changes
Yesterday, I spent quite some time debugging a problem in the particle filter that would have been found easily with `-Wall` (bit-bots/particle_filter#7). A similar problem happened a few months ago (bit-bots/particle_filter#5).
This PR adds the compile flags `-Wall -Werror -Wno-unused` to the motion packages. `-Wall` shows all warnings. `-Werror` treats all warnings as errors, failing the build. I added that one because warnings tend to be ignored by most people. `-Wno-unused` turns off warnings for unused functions or variables which would be annoying when writing new code or debugging things.
This will hopefully lead to less problems that would have been so easily avoidable in the future.

## Necessary checks
- [ ] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

