### PR TITLE
Remove double initialization of walk engine

### DIFF
--- a/bitbots_quintic_walk/src/walk_node.cpp
+++ b/bitbots_quintic_walk/src/walk_node.cpp
@@ -76,9 +76,6 @@ WalkNode::WalkNode(const std::string ns) :
   dynamic_reconfigure::Server<bitbots_quintic_walk::bitbots_quintic_walk_paramsConfig>::CallbackType f;
   f = boost::bind(&bitbots_quintic_walk::WalkNode::reconfCallback, this, _1, _2);
   dyn_reconf_server_->setCallback(f);
-
-  // this has to be done to prevent strange initilization bugs
-  walk_engine_ = WalkEngine(ns);
 }
 
 void WalkNode::run() {


### PR DESCRIPTION
## Proposed changes
This removes a workaround that was added in eab861f8de10cdbc6b6e3a30f358dd3c8fbfaf91 (#143) and results in the error `Tried to advertise a service that is already advertised in this node [/walking/engine/set_parameters]` when launching the walking. @SammyRamone do you know why the workaround was necessary? It seems to be related to the PID controllers. Could you test whatever it was that this line fixed? The walking still seems to work without the line.

## Necessary checks
- [ ] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

