### PR TITLE
Rate.sleep issues in sim

### DIFF
--- a/bitbots_animation_server/src/bitbots_animation_server/animation_node.py
+++ b/bitbots_animation_server/src/bitbots_animation_server/animation_node.py
@@ -18,7 +18,7 @@ from sensor_msgs.msg import Imu, JointState
 from bitbots_animation_server.resource_manager import find_all_animations_by_name
 from humanoid_league_msgs.msg import RobotControlState
 from bitbots_animation_server.spline_animator import SplineAnimator
-
+from bitbots_ros_patches.rate import Rate
 
 class AnimationNode:
     def __init__(self):
@@ -94,52 +94,46 @@ class PlayAnimationAction(object):
 
         animator = self.get_animation_splines(self.current_animation)
         # start animation
-        rate = rospy.Rate(500)
-        current_time = rospy.Time()
+        rate = Rate(500)
 
         while not rospy.is_shutdown() and animator:
-            last_time = current_time
-            current_time = rospy.Time.now()
-            if last_time != current_time:
-                # first check if we have another goal
-                self.check_for_new_goal()
-                new_goal = self._as.current_goal.goal.goal.animation
-                # if there is a new goal, calculate new splines and reset the time
-                if new_goal != self.current_animation:
-                    self.current_animation = new_goal
-                    animator = self.get_animation_splines(self.current_animation)
-                    first = True
+            # first check if we have another goal
+            self.check_for_new_goal()
+            new_goal = self._as.current_goal.goal.goal.animation
+            # if there is a new goal, calculate new splines and reset the time
+            if new_goal != self.current_animation:
+                self.current_animation = new_goal
+                animator = self.get_animation_splines(self.current_animation)
+                first = True
 
-                # if we're here we want to play the next keyframe, cause there is no other goal
-                # compute next pose
-                t = rospy.get_time() - animator.get_start_time()
-                pose = animator.get_positions_rad(t)
-                if pose is None:
-                    # see walking node reset
+            # if we're here we want to play the next keyframe, cause there is no other goal
+            # compute next pose
+            t = rospy.get_time() - animator.get_start_time()
+            pose = animator.get_positions_rad(t)
+            if pose is None:
+                # see walking node reset
 
-                    # animation is finished
-                    # tell it to the hcm
-                    self.send_animation(False, True, goal.hcm, None, None)
-                    self._as.publish_feedback(PlayAnimationFeedback(percent_done=100))
-                    # we give a positive result
-                    self._as.set_succeeded(PlayAnimationResult(True))
-                    return
+                # animation is finished
+                # tell it to the hcm
+                self.send_animation(False, True, goal.hcm, None, None)
+                self._as.publish_feedback(PlayAnimationFeedback(percent_done=100))
+                # we give a positive result
+                self._as.set_succeeded(PlayAnimationResult(True))
+                return
 
-                self.send_animation(first, False, goal.hcm, pose, animator.get_torque(t))
-                first = False  # we have sent the first frame, all frames after this can't be the first
-                perc_done = int(((rospy.get_time() - animator.get_start_time()) / animator.get_duration()) * 100)
-                perc_done = max(0, min(perc_done, 100))
-                self._as.publish_feedback(PlayAnimationFeedback(percent_done=perc_done))
+            self.send_animation(first, False, goal.hcm, pose, animator.get_torque(t))
+            first = False  # we have sent the first frame, all frames after this can't be the first
+            perc_done = int(((rospy.get_time() - animator.get_start_time()) / animator.get_duration()) * 100)
+            perc_done = max(0, min(perc_done, 100))
+            self._as.publish_feedback(PlayAnimationFeedback(percent_done=perc_done))
 
-                try:
-                    # catch exception of moving backwards in time, when restarting simulator
-                    rate.sleep()
-                except rospy.exceptions.ROSTimeMovedBackwardsException:
-                    rospy.logwarn("We moved backwards in time. This is probably because the simulation was reset.")
-                except rospy.exceptions.ROSInterruptException:
-                    exit()
-            else:
-                time.sleep(0.0001)
+            try:
+                # catch exception of moving backwards in time, when restarting simulator
+                rate.sleep()
+            except rospy.exceptions.ROSTimeMovedBackwardsException:
+                rospy.logwarn("We moved backwards in time. This is probably because the simulation was reset.")
+            except rospy.exceptions.ROSInterruptException:
+                exit()
 
     def get_animation_splines(self, animation_name):
         if animation_name not in self.animation_cache:

--- a/bitbots_hcm/scripts/test_publisher.py
+++ b/bitbots_hcm/scripts/test_publisher.py
@@ -3,13 +3,14 @@ import rospy
 import time
 from sensor_msgs.msg import Imu
 from std_msgs.msg import Bool
+from bitbots_ros_patches.rate import Rate
 
 if __name__ == "__main__":
     rospy.init_node("test_pub")
     pub = rospy.Publisher("test", Imu, queue_size=1)
 
     msg = Imu()
-    rate = rospy.Rate(100)
+    rate = Rate(100)
 
     while not rospy.is_shutdown():
         msg.header.stamp = rospy.Time.now()

--- a/bitbots_hcm/src/bitbots_hcm/humanoid_control_module.py
+++ b/bitbots_hcm/src/bitbots_hcm/humanoid_control_module.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import math
 import sys
-import time
 
 import numpy
 

--- a/bitbots_hcm/src/bitbots_hcm/humanoid_control_module.py
+++ b/bitbots_hcm/src/bitbots_hcm/humanoid_control_module.py
@@ -4,7 +4,6 @@ import math
 import sys
 import time
 
-import bitbots_ros_patches
 import numpy
 
 import rospy

--- a/bitbots_hcm/src/bitbots_hcm/humanoid_control_module.py
+++ b/bitbots_hcm/src/bitbots_hcm/humanoid_control_module.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# !/usr/bin/env python3
 import math
 import sys
 import time

--- a/bitbots_hcm/src/bitbots_hcm/training/label.py
+++ b/bitbots_hcm/src/bitbots_hcm/training/label.py
@@ -7,6 +7,7 @@ from geometry_msgs.msg import PointStamped
 from sensor_msgs.msg import Imu, JointState
 
 from bitbots_hcm.training.dataset import Dataset, Frame
+from bitbots_ros_patches.rate import Rate
 
 imu = None
 joint_states = None
@@ -61,7 +62,7 @@ keyboard.add_hotkey('4', key_cb, args='4')
 keyboard.add_hotkey('s', key_cb, args='s')
 
 frequency = 200
-rate = rospy.Rate(frequency)
+rate = Rate(frequency)
 print("Press \'s\' top stop. 0,1,2,3,4 to label stable,front,back,left,right")
 while True:
     frame = Frame(rospy.Time.now(), joint_states=joint_states, imu=imu, cop_l=cop_left, cop_r=cop_right, image=None)

--- a/bitbots_odometry/src/motion_odometry.cpp
+++ b/bitbots_odometry/src/motion_odometry.cpp
@@ -16,7 +16,11 @@ MotionOdometry::MotionOdometry() {
   ros::Subscriber walk_support_state_sub =
       n.subscribe("walk_support_state", 1, &MotionOdometry::supportCallback, this, ros::TransportHints().tcpNoDelay());
   ros::Subscriber kick_support_state_sub =
-      n.subscribe("dynamic_kick_support_state", 1, &MotionOdometry::supportCallback, this, ros::TransportHints().tcpNoDelay());
+      n.subscribe("dynamic_kick_support_state",
+                  1,
+                  &MotionOdometry::supportCallback,
+                  this,
+                  ros::TransportHints().tcpNoDelay());
   ros::Subscriber joint_state_sub =
       n.subscribe("joint_states", 1, &MotionOdometry::jointStateCb, this, ros::TransportHints().tcpNoDelay());
   ros::Subscriber odom_subscriber = n.subscribe("walk_engine_odometry", 1, &MotionOdometry::odomCallback, this);
@@ -39,95 +43,101 @@ MotionOdometry::MotionOdometry() {
 
   while (ros::ok()) {
     ros::spinOnce();
-
-    //check if joint states were received, otherwise we can't provide odometry
-    ros::Duration joints_delta_t = ros::Time::now() - joint_update_time_;
-    if (joints_delta_t.toSec() > 0.05) {
-      ROS_WARN_THROTTLE(30, "No joint states received. Will not provide odometry.");
-    } else {
-      // check if step finished, meaning left->right or right->left support. double support is skipped
-      // the support foot change is published when the joint goals for the last movements are published.
-      // it takes some time till the joints actually reach this position, this can create some offset
-      // but since we skip the double support phase, we basically take the timepoint when the double support phase is
-      // finished. This means both feet did not move and this should create no offset.
-      if ((current_support_state_ == bitbots_msgs::SupportState::LEFT && previous_support_state_ == bitbots_msgs::SupportState::RIGHT) ||
-          (current_support_state_ == bitbots_msgs::SupportState::RIGHT && previous_support_state_ == bitbots_msgs::SupportState::LEFT)) {
+    if (r.sleep()) {
+      //check if joint states were received, otherwise we can't provide odometry
+      ros::Duration joints_delta_t = ros::Time::now() - joint_update_time_;
+      if (joints_delta_t.toSec() > 0.05) {
+        ROS_WARN_THROTTLE(30, "No joint states received. Will not provide odometry.");
+      } else {
+        // check if step finished, meaning left->right or right->left support. double support is skipped
+        // the support foot change is published when the joint goals for the last movements are published.
+        // it takes some time till the joints actually reach this position, this can create some offset
+        // but since we skip the double support phase, we basically take the timepoint when the double support phase is
+        // finished. This means both feet did not move and this should create no offset.
+        if ((current_support_state_ == bitbots_msgs::SupportState::LEFT
+            && previous_support_state_ == bitbots_msgs::SupportState::RIGHT) ||
+            (current_support_state_ == bitbots_msgs::SupportState::RIGHT
+                && previous_support_state_ == bitbots_msgs::SupportState::LEFT)) {
           foot_change_time = current_support_state_time_;
-        if (previous_support_state_ == bitbots_msgs::SupportState::LEFT) {
-          previous_support_link = l_sole_frame_;
-          current_support_link = r_sole_frame_;
-        } else {
-          previous_support_link = r_sole_frame_;
-          current_support_link = l_sole_frame_;
+          if (previous_support_state_ == bitbots_msgs::SupportState::LEFT) {
+            previous_support_link = l_sole_frame_;
+            current_support_link = r_sole_frame_;
+          } else {
+            previous_support_link = r_sole_frame_;
+            current_support_link = l_sole_frame_;
+          }
+
+          try {
+            // add the transform between previous and current support link to the odometry transform.
+            // we wait a bit for the transform as the joint messages are maybe a bit behind
+            geometry_msgs::TransformStamped previous_to_current_support_msg =
+                tf_buffer_
+                    .lookupTransform(previous_support_link, current_support_link, foot_change_time, ros::Duration(0.1));
+            tf2::Transform previous_to_current_support = tf2::Transform();
+            tf2::fromMsg(previous_to_current_support_msg.transform, previous_to_current_support);
+            // setting translation in z axis, pitch and roll to zero to stop the robot from lifting up
+            previous_to_current_support.setOrigin({
+                                                      previous_to_current_support.getOrigin().x(),
+                                                      previous_to_current_support.getOrigin().y(),
+                                                      0});
+            tf2::Quaternion q;
+            q.setRPY(0, 0, tf2::getYaw(previous_to_current_support.getRotation()));
+            previous_to_current_support.setRotation(q);
+            odometry_to_support_foot_ = odometry_to_support_foot_ * previous_to_current_support;
+          } catch (tf2::TransformException &ex) {
+            ROS_WARN("%s", ex.what());
+            ros::Duration(1.0).sleep();
+            continue;
+          }
+
+          // update current support link for transform from foot to base link
+          previous_support_link = current_support_link;
+
+          // remember the support state change but skip the double support phase
+          if (current_support_state_ != bitbots_msgs::SupportState::DOUBLE) {
+            previous_support_state_ = current_support_state_;
+          }
         }
 
+        //publish odometry and if wanted transform to base_link
         try {
-          // add the transform between previous and current support link to the odometry transform.
-          // we wait a bit for the transform as the joint messages are maybe a bit behind
-          geometry_msgs::TransformStamped previous_to_current_support_msg =
-              tf_buffer_.lookupTransform(previous_support_link, current_support_link, foot_change_time, ros::Duration(0.1));
-          tf2::Transform previous_to_current_support = tf2::Transform();
-          tf2::fromMsg(previous_to_current_support_msg.transform, previous_to_current_support);
-          // setting translation in z axis, pitch and roll to zero to stop the robot from lifting up
-          previous_to_current_support.setOrigin({
-                                                previous_to_current_support.getOrigin().x(),
-                                                previous_to_current_support.getOrigin().y(),
-                                                0});
-          tf2::Quaternion q;
-          q.setRPY(0, 0, tf2::getYaw(previous_to_current_support.getRotation()));
-          previous_to_current_support.setRotation(q);
-          odometry_to_support_foot_ = odometry_to_support_foot_ * previous_to_current_support;
+          geometry_msgs::TransformStamped
+              current_support_to_base_msg =
+              tf_buffer_.lookupTransform(previous_support_link, base_link_frame_, ros::Time(0));
+          tf2::Transform current_support_to_base;
+          tf2::fromMsg(current_support_to_base_msg.transform, current_support_to_base);
+          tf2::Transform odom_to_base_link = odometry_to_support_foot_ * current_support_to_base;
+          geometry_msgs::TransformStamped odom_to_base_link_msg = geometry_msgs::TransformStamped();
+          odom_to_base_link_msg.transform = tf2::toMsg(odom_to_base_link);
+          odom_to_base_link_msg.header.stamp = current_support_to_base_msg.header.stamp;
+          odom_to_base_link_msg.header.frame_id = odom_frame_;
+          odom_to_base_link_msg.child_frame_id = base_link_frame_;
+          if (publish_walk_odom_tf) {
+            ROS_WARN_ONCE("Sending Tf from walk odometry directly");
+            br.sendTransform(odom_to_base_link_msg);
+          }
+
+          // odometry as message
+          nav_msgs::Odometry odom_msg;
+          odom_msg.header.stamp = current_support_to_base_msg.header.stamp;
+          odom_msg.header.frame_id = odom_frame_;
+          odom_msg.child_frame_id = base_link_frame_;
+          odom_msg.pose.pose.position.x = odom_to_base_link_msg.transform.translation.x;
+          odom_msg.pose.pose.position.y = odom_to_base_link_msg.transform.translation.y;
+          odom_msg.pose.pose.position.z = odom_to_base_link_msg.transform.translation.z;
+          odom_msg.pose.pose.orientation = odom_to_base_link_msg.transform.rotation;
+          odom_msg.twist = current_odom_msg_.twist;
+          pub_odometry.publish(odom_msg);
+
         } catch (tf2::TransformException &ex) {
           ROS_WARN("%s", ex.what());
-          ros::Duration(1.0).sleep();
+          ros::Duration(0.1).sleep();
           continue;
         }
-
-        // update current support link for transform from foot to base link
-        previous_support_link = current_support_link;
-
-        // remember the support state change but skip the double support phase
-        if (current_support_state_ != bitbots_msgs::SupportState::DOUBLE){
-            previous_support_state_ = current_support_state_;
-        }
       }
-
-      //publish odometry and if wanted transform to base_link
-      try {
-        geometry_msgs::TransformStamped
-            current_support_to_base_msg = tf_buffer_.lookupTransform(previous_support_link, base_link_frame_, ros::Time(0));
-        tf2::Transform current_support_to_base;
-        tf2::fromMsg(current_support_to_base_msg.transform, current_support_to_base);
-        tf2::Transform odom_to_base_link = odometry_to_support_foot_ * current_support_to_base;
-        geometry_msgs::TransformStamped odom_to_base_link_msg = geometry_msgs::TransformStamped();
-        odom_to_base_link_msg.transform = tf2::toMsg(odom_to_base_link);
-        odom_to_base_link_msg.header.stamp = current_support_to_base_msg.header.stamp;
-        odom_to_base_link_msg.header.frame_id = odom_frame_;
-        odom_to_base_link_msg.child_frame_id = base_link_frame_;
-        if (publish_walk_odom_tf) {
-          ROS_WARN_ONCE("Sending Tf from walk odometry directly");
-          br.sendTransform(odom_to_base_link_msg);
-        }
-
-        // odometry as message
-        nav_msgs::Odometry odom_msg;
-        odom_msg.header.stamp = current_support_to_base_msg.header.stamp;
-        odom_msg.header.frame_id = odom_frame_;
-        odom_msg.child_frame_id = base_link_frame_;
-        odom_msg.pose.pose.position.x = odom_to_base_link_msg.transform.translation.x;
-        odom_msg.pose.pose.position.y = odom_to_base_link_msg.transform.translation.y;
-        odom_msg.pose.pose.position.z = odom_to_base_link_msg.transform.translation.z;
-        odom_msg.pose.pose.orientation = odom_to_base_link_msg.transform.rotation;
-        odom_msg.twist = current_odom_msg_.twist;
-        pub_odometry.publish(odom_msg);
-
-      } catch (tf2::TransformException &ex) {
-        ROS_WARN("%s", ex.what());
-        ros::Duration(0.1).sleep();
-        continue;
-      }
+    } else {
+      sleep(0.0001);
     }
-    r.sleep();
   }
 }
 
@@ -140,20 +150,22 @@ void MotionOdometry::supportCallback(const bitbots_msgs::SupportState msg) {
     std::string current_support_link;
     if (current_support_state_ == bitbots_msgs::SupportState::LEFT) {
       previous_support_state_ = bitbots_msgs::SupportState::RIGHT;
-      current_support_link= l_sole_frame_;
+      current_support_link = l_sole_frame_;
     } else {
       previous_support_state_ = bitbots_msgs::SupportState::LEFT;
-      current_support_link= r_sole_frame_;
+      current_support_link = r_sole_frame_;
     }
     // on receiving first support state we should also set the location in the world correctly
     // we assume that our baseline is on x=0 and y=0
-    try{
-        geometry_msgs::TransformStamped
-                base_to_current_support_msg = tf_buffer_.lookupTransform(base_link_frame_, current_support_link, ros::Time(0), ros::Duration(10.0));
-        odometry_to_support_foot_.setOrigin({-1 * base_to_current_support_msg.transform.translation.x,
-                                            -1 * base_to_current_support_msg.transform.translation.y, 0});
-    }catch (tf2::TransformException ex){
-        ROS_WARN("Could not initialize motion odometry correctly, since there were no transforms available fast enough on startup. Will initialize with 0,0,0");
+    try {
+      geometry_msgs::TransformStamped
+          base_to_current_support_msg =
+          tf_buffer_.lookupTransform(base_link_frame_, current_support_link, ros::Time(0), ros::Duration(10.0));
+      odometry_to_support_foot_.setOrigin({-1 * base_to_current_support_msg.transform.translation.x,
+                                           -1 * base_to_current_support_msg.transform.translation.y, 0});
+    } catch (tf2::TransformException ex) {
+      ROS_WARN(
+          "Could not initialize motion odometry correctly, since there were no transforms available fast enough on startup. Will initialize with 0,0,0");
     }
   }
 }

--- a/bitbots_odometry/src/odometry_fuser.cpp
+++ b/bitbots_odometry/src/odometry_fuser.cpp
@@ -19,13 +19,13 @@ OdometryFuser::OdometryFuser() : tf_listener_(tf_buffer_), support_state_cache_(
   pnh.param<std::string>("rotation_frame", rotation_frame_, "rotation");
   pnh.param<std::string>("imu_frame", imu_frame_, "imu_frame");
 
-  auto callback = [&](const bitbots_msgs::SupportState::ConstPtr &msg){support_state_cache_.add(msg);};
+  auto callback = [&](const bitbots_msgs::SupportState::ConstPtr &msg) { support_state_cache_.add(msg); };
 
   ros::Subscriber walk_support_state_sub = n.subscribe<bitbots_msgs::SupportState>(
-    "walk_support_state", 1, callback);
+      "walk_support_state", 1, callback);
 
   ros::Subscriber kick_support_state_sub = n.subscribe<bitbots_msgs::SupportState>(
-    "dynamic_kick_support_state", 1, callback);
+      "dynamic_kick_support_state", 1, callback);
 
   message_filters::Subscriber<sensor_msgs::Imu> imu_sub(n, "imu/data", 1);
   message_filters::Subscriber<nav_msgs::Odometry> motion_odom_sub(n, "motion_odometry", 1);
@@ -55,84 +55,85 @@ OdometryFuser::OdometryFuser() : tf_listener_(tf_buffer_), support_state_cache_(
   ros::Time last_time_stamp;
   while (ros::ok()) {
     ros::spinOnce();
+    if (r.sleep()) {
+      // in simulation, the time does not always advance between loop iteration
+      // in that case, we do not want to republish the transform
+      if (fused_time_ == last_time_stamp) {
+        r.sleep();
+        continue;
+      }
 
-    // in simulation, the time does not always advance between loop iteration
-    // in that case, we do not want to republish the transform
-    if (fused_time_ == last_time_stamp) {
-      r.sleep();
-      continue;
+      // get roll an pitch from imu
+      tf2::Quaternion imu_orientation;
+      tf2::fromMsg(imu_data_.orientation, imu_orientation);
+
+      // get motion_odom transform
+      tf2::Transform motion_odometry;
+      tf2::fromMsg(odom_data_.pose.pose, motion_odometry);
+
+      // combine orientations to new quaternion if IMU is active, use purely odom otherwise
+      tf2::Transform fused_odometry;
+
+      // compute the point of rotation (in base_link frame)
+      tf2::Transform rotation_point_in_base = getCurrentRotationPoint();
+      // publish rotation point as debug
+      geometry_msgs::TransformStamped rotation_point_msg;
+      rotation_point_msg.header.stamp = fused_time_;
+      rotation_point_msg.header.frame_id = base_link_frame_;
+      rotation_point_msg.child_frame_id = rotation_frame_;
+      geometry_msgs::Transform rotation_point_transform_msg;
+      rotation_point_transform_msg = tf2::toMsg(rotation_point_in_base);
+      rotation_point_msg.transform = rotation_point_transform_msg;
+      br.sendTransform(rotation_point_msg);
+      // get base_link in rotation point frame
+      tf2::Transform base_link_in_rotation_point = rotation_point_in_base.inverse();
+
+      // get only translation and yaw from motion odometry
+      tf2::Quaternion odom_orientation_yaw = getCurrentMotionOdomYaw(
+          motion_odometry.getRotation());
+      tf2::Transform motion_odometry_yaw;
+      motion_odometry_yaw.setRotation(odom_orientation_yaw);
+      motion_odometry_yaw.setOrigin(motion_odometry.getOrigin());
+
+      // Get the rotation offset between the IMU and the baselink
+      tf2::Transform imu_mounting_offset;
+      try {
+        geometry_msgs::TransformStamped imu_mounting_transform = tf_buffer_.lookupTransform(
+            base_link_frame_, imu_frame_, fused_time_);
+        fromMsg(imu_mounting_transform.transform, imu_mounting_offset);
+      } catch (tf2::TransformException ex) {
+        ROS_ERROR("Not able to use the IMU%s", ex.what());
+      }
+
+      // get imu transform without yaw
+      tf2::Quaternion imu_orientation_without_yaw_component = getCurrentImuRotationWithoutYaw(
+          imu_orientation * imu_mounting_offset.getRotation());
+      tf2::Transform imu_without_yaw_component;
+      imu_without_yaw_component.setRotation(imu_orientation_without_yaw_component);
+      imu_without_yaw_component.setOrigin({0, 0, 0});
+
+      // transformation chain to get correctly rotated odom frame
+      // go to the rotation point in the odom frame. rotate the transform to the base link at this point
+      fused_odometry =
+          motion_odometry_yaw * rotation_point_in_base * imu_without_yaw_component * base_link_in_rotation_point;
+
+      // combine it all into a tf
+      tf.header.stamp = fused_time_;
+      tf.header.frame_id = odom_frame_;
+      tf.child_frame_id = base_link_frame_;
+      geometry_msgs::Transform fused_odom_msg;
+      fused_odom_msg = toMsg(fused_odometry);
+      tf.transform = fused_odom_msg;
+      br.sendTransform(tf);
+
+      last_time_stamp = fused_time_;
+    } else {
+      sleep(0.0001);
     }
-
-    // get roll an pitch from imu
-    tf2::Quaternion imu_orientation;
-    tf2::fromMsg(imu_data_.orientation, imu_orientation);
-
-    // get motion_odom transform
-    tf2::Transform motion_odometry;
-    tf2::fromMsg(odom_data_.pose.pose, motion_odometry);
-
-    // combine orientations to new quaternion if IMU is active, use purely odom otherwise
-    tf2::Transform fused_odometry;
-
-    // compute the point of rotation (in base_link frame)
-    tf2::Transform rotation_point_in_base = getCurrentRotationPoint();
-    // publish rotation point as debug
-    geometry_msgs::TransformStamped rotation_point_msg;
-    rotation_point_msg.header.stamp = fused_time_;
-    rotation_point_msg.header.frame_id = base_link_frame_;
-    rotation_point_msg.child_frame_id = rotation_frame_;
-    geometry_msgs::Transform rotation_point_transform_msg;
-    rotation_point_transform_msg = tf2::toMsg(rotation_point_in_base);
-    rotation_point_msg.transform = rotation_point_transform_msg;
-    br.sendTransform(rotation_point_msg);
-    // get base_link in rotation point frame
-    tf2::Transform base_link_in_rotation_point = rotation_point_in_base.inverse();
-
-    // get only translation and yaw from motion odometry
-    tf2::Quaternion odom_orientation_yaw = getCurrentMotionOdomYaw(
-      motion_odometry.getRotation());
-    tf2::Transform motion_odometry_yaw;
-    motion_odometry_yaw.setRotation(odom_orientation_yaw);
-    motion_odometry_yaw.setOrigin(motion_odometry.getOrigin());
-
-    // Get the rotation offset between the IMU and the baselink
-    tf2::Transform imu_mounting_offset;
-    try {
-      geometry_msgs::TransformStamped imu_mounting_transform = tf_buffer_.lookupTransform(
-        base_link_frame_, imu_frame_, fused_time_);
-      fromMsg(imu_mounting_transform.transform, imu_mounting_offset);
-    } catch (tf2::TransformException ex) {
-      ROS_ERROR("Not able to use the IMU%s", ex.what());
-    }
-
-    // get imu transform without yaw
-    tf2::Quaternion imu_orientation_without_yaw_component = getCurrentImuRotationWithoutYaw(
-      imu_orientation * imu_mounting_offset.getRotation());
-    tf2::Transform imu_without_yaw_component;
-    imu_without_yaw_component.setRotation(imu_orientation_without_yaw_component);
-    imu_without_yaw_component.setOrigin({0, 0, 0});
-
-    // transformation chain to get correctly rotated odom frame
-    // go to the rotation point in the odom frame. rotate the transform to the base link at this point
-    fused_odometry = motion_odometry_yaw * rotation_point_in_base * imu_without_yaw_component * base_link_in_rotation_point;
-
-    // combine it all into a tf
-    tf.header.stamp = fused_time_;
-    tf.header.frame_id = odom_frame_;
-    tf.child_frame_id = base_link_frame_;
-    geometry_msgs::Transform fused_odom_msg;
-    fused_odom_msg = toMsg(fused_odometry);
-    tf.transform = fused_odom_msg;
-    br.sendTransform(tf);
-
-    last_time_stamp = fused_time_;
-
-    r.sleep();
   }
 }
 
-tf2::Quaternion OdometryFuser::getCurrentMotionOdomYaw(tf2::Quaternion motion_odom_rotation)
-{
+tf2::Quaternion OdometryFuser::getCurrentMotionOdomYaw(tf2::Quaternion motion_odom_rotation) {
   // Convert tf to eigen quaternion
   Eigen::Quaterniond eigen_quat, out;
   tf2::convert(motion_odom_rotation, eigen_quat);
@@ -146,15 +147,13 @@ tf2::Quaternion OdometryFuser::getCurrentMotionOdomYaw(tf2::Quaternion motion_od
   return odom_orientation_yaw;
 }
 
-tf2::Quaternion OdometryFuser::getCurrentImuRotationWithoutYaw(tf2::Quaternion imu_rotation)
-{
+tf2::Quaternion OdometryFuser::getCurrentImuRotationWithoutYaw(tf2::Quaternion imu_rotation) {
   // Calculate robot orientation vector
-  tf2::Vector3 robot_vector = tf2::Vector3(0,0,1);
+  tf2::Vector3 robot_vector = tf2::Vector3(0, 0, 1);
   tf2::Vector3 robot_vector_rotated = robot_vector.rotate(imu_rotation.getAxis(), imu_rotation.getAngle()).normalize();
 
   // Check if the robots orientation is near the yaw singularity
-  if (robot_vector_rotated.z() < 0.2)
-  {
+  if (robot_vector_rotated.z() < 0.2) {
     // Use ony a IMU offset during the singularity
     return imu_rotation;
   }
@@ -176,7 +175,6 @@ tf2::Quaternion OdometryFuser::getCurrentImuRotationWithoutYaw(tf2::Quaternion i
 
 tf2::Transform OdometryFuser::getCurrentRotationPoint() {
 
-
   geometry_msgs::TransformStamped rotation_point;
   tf2::Transform rotation_point_tf;
 
@@ -192,7 +190,8 @@ tf2::Transform OdometryFuser::getCurrentRotationPoint() {
   tf_buffer_.canTransform(r_sole_frame_, l_sole_frame_, fused_time_, ros::Duration(0.1));
 
   // otherwise point of rotation is current support foot sole or center point of the soles if double support
-  if (current_support_state == bitbots_msgs::SupportState::RIGHT || current_support_state == bitbots_msgs::SupportState::LEFT) {
+  if (current_support_state == bitbots_msgs::SupportState::RIGHT
+      || current_support_state == bitbots_msgs::SupportState::LEFT) {
     try {
       std::string support_frame;
       if (current_support_state == bitbots_msgs::SupportState::RIGHT)
@@ -219,11 +218,12 @@ tf2::Transform OdometryFuser::getCurrentRotationPoint() {
     // we only want to have the half transform to get the point between the feet
     tf2::Transform l_to_center_tf;
     l_to_center_tf
-        .setOrigin({l_to_r_sole_tf.getOrigin().x() /2, l_to_r_sole_tf.getOrigin().y() /2, l_to_r_sole_tf.getOrigin().z() /2});
+        .setOrigin({l_to_r_sole_tf.getOrigin().x() / 2, l_to_r_sole_tf.getOrigin().y() / 2,
+                    l_to_r_sole_tf.getOrigin().z() / 2});
 
     // Set to zero rotation, because the rotation measurement is done by the imu
     tf2::Quaternion zero_rotation;
-    zero_rotation.setRPY(0,0,0);
+    zero_rotation.setRPY(0, 0, 0);
     l_to_center_tf.setRotation(zero_rotation);
 
     rotation_point_tf = base_to_l_sole_tf * l_to_center_tf;

--- a/bitbots_quintic_walk/config/walking_wolfgang_simulator.yaml
+++ b/bitbots_quintic_walk/config/walking_wolfgang_simulator.yaml
@@ -76,7 +76,7 @@ walking:
 
   node:
     # update frequency of the engine
-    engine_freq: 100.0
+    engine_freq: 200.0
 
     # parameters for bioIK
     ik_timeout: 0.01


### PR DESCRIPTION
## Proposed changes
The rospy and roscpp implementation of rate.sleep() does not work correctly when the specified rate is higher than the simulation rate. We need to handle this explicitly.

Python uses wrapper, c++ not. We will probably do this differently with ROS2 anyway.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

