### PR TITLE
deactivate unnecessary publishing of pid states

### DIFF
--- a/bitbots_dynup/config/dynup_robot.yaml
+++ b/bitbots_dynup/config/dynup_robot.yaml
@@ -69,7 +69,7 @@ dynup:
     i_clamp_min: 0
     i_clamp_max: 0
     antiwindup: True
-    publish_state: True
+    publish_state: False
   pid_trunk_pitch:
     p: -0.42
     i: -5.31646
@@ -78,4 +78,4 @@ dynup:
     i_clamp_min: 0
     i_clamp_max: 0
     antiwindup: True
-    publish_state: True
+    publish_state: False

--- a/bitbots_dynup/config/dynup_sim.yaml
+++ b/bitbots_dynup/config/dynup_sim.yaml
@@ -69,7 +69,7 @@ dynup:
     i_clamp_min: 0
     i_clamp_max: 0
     antiwindup: True
-    publish_state: True
+    publish_state: False
   pid_trunk_pitch:
     p: -0.42
     i: -5.31646
@@ -78,4 +78,4 @@ dynup:
     i_clamp_min: 0
     i_clamp_max: 0
     antiwindup: True
-    publish_state: True
+    publish_state: False

--- a/bitbots_dynup/config/dynup_sim_darwin.yaml
+++ b/bitbots_dynup/config/dynup_sim_darwin.yaml
@@ -65,7 +65,7 @@ dynup:
     i_clamp_min: 0
     i_clamp_max: 0
     antiwindup: True
-    publish_state: True
+    publish_state: False
   pid_trunk_pitch:
     p: -0.42
     i: -5.31646
@@ -74,4 +74,4 @@ dynup:
     i_clamp_min: 0
     i_clamp_max: 0
     antiwindup: True
-    publish_state: True
+    publish_state: False

--- a/bitbots_quintic_walk/config/walking_wolfgang_robot.yaml
+++ b/bitbots_quintic_walk/config/walking_wolfgang_robot.yaml
@@ -120,7 +120,7 @@ walking:
     i_clamp_min: 0
     i_clamp_max: 0
     antiwindup: False
-    publish_state: True
+    publish_state: False
 
   pid_trunk_fused_roll:
     p: 0.111
@@ -130,4 +130,4 @@ walking:
     i_clamp_min: 0
     i_clamp_max: 0
     antiwindup: False
-    publish_state: True
+    publish_state: False

--- a/bitbots_quintic_walk/config/walking_wolfgang_robot_no_limits.yaml
+++ b/bitbots_quintic_walk/config/walking_wolfgang_robot_no_limits.yaml
@@ -114,7 +114,7 @@ walking:
     i_clamp_min: 0
     i_clamp_max: 0
     antiwindup: False
-    publish_state: True
+    publish_state: False
 
   pid_trunk_fused_roll:
     p: 0.111
@@ -124,4 +124,4 @@ walking:
     i_clamp_min: 0
     i_clamp_max: 0
     antiwindup: False
-    publish_state: True
+    publish_state: False

--- a/bitbots_quintic_walk/config/walking_wolfgang_simulator.yaml
+++ b/bitbots_quintic_walk/config/walking_wolfgang_simulator.yaml
@@ -120,7 +120,7 @@ walking:
     i_clamp_min: 0
     i_clamp_max: 0
     antiwindup: False
-    publish_state: True
+    publish_state: False
 
   pid_trunk_fused_roll:
     p: 0.111
@@ -130,4 +130,4 @@ walking:
     i_clamp_min: 0
     i_clamp_max: 0
     antiwindup: False
-    publish_state: True
+    publish_state: False

--- a/bitbots_quintic_walk/config/walking_wolfgang_viz.yaml
+++ b/bitbots_quintic_walk/config/walking_wolfgang_viz.yaml
@@ -120,7 +120,7 @@ walking:
     i_clamp_min: 0
     i_clamp_max: 0
     antiwindup: False
-    publish_state: True
+    publish_state: False
 
   pid_trunk_fused_roll:
     p: 0
@@ -130,4 +130,4 @@ walking:
     i_clamp_min: 0
     i_clamp_max: 0
     antiwindup: False
-    publish_state: True
+    publish_state: False


### PR DESCRIPTION
## Proposed changes
Just deactivate publishing of PID controller states as default. Can be reactivated in dyn reconf anyway if necessary. Reduces CPU load and bandwith.


## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

