### PR TITLE
fixes initial walkready

### DIFF
--- a/bitbots_dynup/cfg/bitbots_dynup_params.cfg
+++ b/bitbots_dynup/cfg/bitbots_dynup_params.cfg
@@ -34,6 +34,10 @@ group_engine.add("trunk_height", double_t, 2,
 group_engine.add("trunk_pitch", double_t, 2,
                  "Pitch of the trunk at the end [deg]",
                  min=-90, max=90)
+group_engine.add("time_walkready", double_t, 2,
+                 "Time used when calling walkready as direction [s]",
+                 min=0, max=10)
+
 
 #Rise spline params
 group_engine_rise = group_engine.add_group("Rise", type="hide")

--- a/bitbots_dynup/config/dynup_robot.yaml
+++ b/bitbots_dynup/config/dynup_robot.yaml
@@ -44,7 +44,7 @@ dynup:
   trunk_x_front: 0.091
   wait_in_squat_front: 0.165
 
-
+  time_walkready: 2.0
   # Rise
   rise_time: 0.84
 

--- a/bitbots_dynup/config/dynup_sim.yaml
+++ b/bitbots_dynup/config/dynup_sim.yaml
@@ -45,6 +45,7 @@ dynup:
   wait_in_squat_front: 0.165
 
 
+  time_walkready: 2.0
   # Rise
   rise_time: 0.84
 

--- a/bitbots_dynup/config/dynup_sim_darwin.yaml
+++ b/bitbots_dynup/config/dynup_sim_darwin.yaml
@@ -41,6 +41,7 @@ dynup:
   time_to_squat: 1
   wait_in_squat_front: 1
 
+  time_walkready: 3.0
   # Rise
   rise_time: 1
 

--- a/bitbots_dynup/src/dynup_engine.cpp
+++ b/bitbots_dynup/src/dynup_engine.cpp
@@ -670,6 +670,9 @@ void DynupEngine::setGoals(const DynupRequest &goals) {
   } else if (goals.direction == "back_only") {
     duration_ = calcBackSplines();
     direction_ = 5;
+  } else if (goals.direction == "walkready") {
+    duration_ = calcRiseSplines(params_.time_walkready);
+    direction_ = 6;
   } else {
     ROS_ERROR("Provided direction not known");
   }

--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/decisions/decisions.py
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/decisions/decisions.py
@@ -30,7 +30,7 @@ class StartHCM(AbstractDecisionElement):
         """
         We check if any joint is has an offset from the walkready pose which is higher than a threshold
         """
-        if self.blackboard.current_joint_state is None:
+        if self.blackboard.current_joint_state is None or self.blackboard.current_joint_state == []:
             return False
         i = 0
         for joint_name in self.blackboard.current_joint_state.name:

--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/hcm.dsd
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/hcm.dsd
@@ -5,7 +5,7 @@ $PickedUp
 
 -->HCM
 $StartHCM
-    NOT_WALKREADY --> @PlayAnimationDynup + direction:rise + initial:true
+    NOT_WALKREADY --> @PlayAnimationDynup + direction:walkready + initial:true
     SHUTDOWN_REQUESTED --> #ShutDownProcedure
     SHUTDOWN_WHILE_HARDWARE_PROBLEM --> @StayShutDown
     RUNNING --> $Stop
@@ -24,7 +24,7 @@ $StartHCM
                         PRESSURE_NOT_STARTED --> @WaitForPressureStartup
                         PROBLEM --> @WaitForPressure
                         OKAY --> $PickedUp
-                            PICKED_UP --> @PlayAnimationDynup + direction:rise, @StayPickedUp
+                            PICKED_UP --> @PlayAnimationDynup + direction:walkready, @StayPickedUp
                             ON_GROUND --> $Fallen
                                 FALLEN_FRONT --> @CancelGoals, @PlayAnimationDynup + direction:front
                                 FALLEN_BACK --> @CancelGoals, @SetFootZero, @PlayAnimationDynup + direction:back


### PR DESCRIPTION
The simulation sends an empty joint state message at start which confused us. Furthermore we always used dynup rise to go into walkready, but this can be quiet fast. Now we can do this slower


## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

