### PR TITLE
HCM now goes into walkready again

### DIFF
--- a/bitbots_hcm/config/hcm_wolfgang.yaml
+++ b/bitbots_hcm/config/hcm_wolfgang.yaml
@@ -30,7 +30,7 @@ hcm:
     motor_off: "sit"
     init: "init"
     anim_package: "wolfgang_animations"
-    walkready_pose_threshold: 5 # [deg]
+    walkready_pose_threshold: 10 # [deg]
 
   # Falling
   stand_up_active: true # enables the robot to stand up automatically

--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/hcm.dsd
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/hcm.dsd
@@ -44,4 +44,6 @@ $StartHCM
                                                 STAY_WALKING --> @StayWalking
                                                 NOT_WALKING --> $Kicking
                                                     KICKING --> @StayKicking
-                                                    NOT_KICKING --> @StayControlable
+                                                    NOT_KICKING -->  $Controlable
+                                                        NOT_WALKREADY --> @PlayAnimationDynup + direction:walkready + initial:true
+                                                        WALKREADY --> @StayControlable

--- a/bitbots_hcm/src/bitbots_hcm/humanoid_control_module.py
+++ b/bitbots_hcm/src/bitbots_hcm/humanoid_control_module.py
@@ -135,7 +135,8 @@ class HardwareControlManager:
     def dynup_callback(self, msg):
         if self.blackboard.current_state in [RobotControlState.STARTUP,
                                              RobotControlState.FALLEN,
-                                             RobotControlState.GETTING_UP]:
+                                             RobotControlState.GETTING_UP,
+                                             RobotControlState.ANIMATION_RUNNING]:
             self.joint_goal_publisher.publish(msg)
 
     def head_goal_callback(self, msg):


### PR DESCRIPTION
## Proposed changes
When we get penalized we go back into init. HCM now checks this and goes back into walkready, so that we dont have issues when we start walking.
Basically reverts https://github.com/bit-bots/bitbots_motion/pull/189

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

