### PR TITLE
Fix walkready animation call from behavior

### DIFF
--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/actions/play_animation.py
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/actions/play_animation.py
@@ -2,6 +2,7 @@ import rospy
 import actionlib
 import humanoid_league_msgs.msg
 import bitbots_msgs.msg
+from actionlib_msgs.msg import GoalStatus
 from dynamic_stack_decider.abstract_action_element import AbstractActionElement
 from bitbots_hcm.hcm_dsd.hcm_blackboard import HcmBlackboard
 from time import sleep
@@ -81,7 +82,7 @@ class AbstractPlayAnimation(AbstractActionElement):
 
     def animation_finished(self):
         state = self.blackboard.animation_action_client.get_state()
-        return state == 3
+        return state in [GoalStatus.PREEMPTED, GoalStatus.SUCCEEDED, GoalStatus.ABORTED, GoalStatus.REJECTED, GoalStatus.LOST]
 
 
 class PlayAnimationStandUpFront(AbstractPlayAnimation):
@@ -218,4 +219,4 @@ class PlayAnimationDynup(AbstractActionElement):
 
     def animation_finished(self):
         state = self.blackboard.dynup_action_client.get_state()
-        return state == 3
+        return state in [GoalStatus.PREEMPTED, GoalStatus.SUCCEEDED, GoalStatus.ABORTED, GoalStatus.REJECTED, GoalStatus.LOST]

--- a/bitbots_hcm/src/bitbots_hcm/humanoid_control_module.py
+++ b/bitbots_hcm/src/bitbots_hcm/humanoid_control_module.py
@@ -135,7 +135,8 @@ class HardwareControlManager:
     def dynup_callback(self, msg):
         if self.blackboard.current_state in [RobotControlState.STARTUP,
                                              RobotControlState.FALLEN,
-                                             RobotControlState.GETTING_UP]:
+                                             RobotControlState.GETTING_UP,
+                                             RobotControlState.CONTROLLABLE]:
             self.joint_goal_publisher.publish(msg)
 
     def head_goal_callback(self, msg):


### PR DESCRIPTION
## Proposed changes
* Enable walkready during `CONTROLLABLE`
* Fix finished

This should fix the that the robot falls down after the penalty.