### PR TITLE
HCM fixes

### DIFF
--- a/bitbots_dynup/config/dynup_sim.yaml
+++ b/bitbots_dynup/config/dynup_sim.yaml
@@ -14,6 +14,7 @@ dynup:
   #arm_side_offset: 0.163
   arm_side_offset: 0.13 #front
 
+  time_walkready: 2.0
 
   # Back
   arms_angle_back: 113.75

--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/hcm.dsd
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/hcm.dsd
@@ -5,10 +5,9 @@ $PickedUp
 
 -->HCM
 $StartHCM
-    NOT_WALKREADY --> @PlayAnimationDynup + direction:walkready + initial:true
     SHUTDOWN_REQUESTED --> #ShutDownProcedure
     SHUTDOWN_WHILE_HARDWARE_PROBLEM --> @StayShutDown
-    RUNNING --> $Stop
+    ELSE --> $Stop
         STOPPED -->  @ForceStopWalking, @PlayAnimationStopped, @StayStopped
         FREE -->$Record
             RECORD_ACTIVE --> @StayRecord

--- a/bitbots_hcm/src/bitbots_hcm/humanoid_control_module.py
+++ b/bitbots_hcm/src/bitbots_hcm/humanoid_control_module.py
@@ -159,7 +159,7 @@ class HardwareControlManager:
             self.joint_goal_publisher.publish(msg)
 
     def kick_goal_callback(self, msg):
-        if self.blackboard.current_state == RobotControlState.KICKING:
+        if self.blackboard.current_state in [RobotControlState.KICKING, RobotControlState.CONTROLLABLE]:
             # we can perform a kick
             self.joint_goal_publisher.publish(msg)
 


### PR DESCRIPTION
## Proposed changes
Removes startup walkready and gives option to disable HCM on the fly for penalty shootout


## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

