### PR TITLE
add parameter to make foot move further

### DIFF
--- a/bitbots_dynamic_kick/cfg/bitbots_dynamic_kick_params.cfg
+++ b/bitbots_dynamic_kick/cfg/bitbots_dynamic_kick_params.cfg
@@ -36,6 +36,9 @@ group_engine_distances.add("trunk_pitch", double_t, 4,
 group_engine_distances.add("trunk_yaw", double_t, 4,
                            "Yaw of the trunk, positive means turning toward the kicking foot [rad]",
                            min=-1, max=1)
+group_engine_distances.add("foot_extra_forward", double_t, 4,
+                           "How much the foot position during kick will be shifted forward to make sure we actually hit the ball [m]",
+                           min=0, max=1)
 
 group_engine_timings = group_engine.add_group("Timings")
 group_engine_timings.add("move_trunk_time", double_t, 3,

--- a/bitbots_dynamic_kick/config/kick_config.yaml
+++ b/bitbots_dynamic_kick/config/kick_config.yaml
@@ -9,6 +9,7 @@ trunk_height: 0.39
 trunk_roll: 0.101229096615671
 trunk_pitch: -0.136135681655558
 trunk_yaw: 0.0558505360638186
+foot_x_extra: 0.05
 
 # Timings
 move_trunk_time: 0.56

--- a/bitbots_dynamic_kick/config/kick_config_unstable.yaml
+++ b/bitbots_dynamic_kick/config/kick_config_unstable.yaml
@@ -17,3 +17,4 @@ unstable:
   trunk_roll: 0.102974425867665
   trunk_yaw: 0.296705972839036
   use_center_of_pressure: false
+  foot_x_extra: 0.00

--- a/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_engine.h
+++ b/bitbots_dynamic_kick/include/bitbots_dynamic_kick/kick_engine.h
@@ -25,6 +25,7 @@ struct KickParams {
   double foot_distance;
   double kick_windup_distance;
   double trunk_height;
+  double foot_extra_forward;
 
   double trunk_roll;
   double trunk_pitch;

--- a/bitbots_dynamic_kick/src/kick_engine.cpp
+++ b/bitbots_dynamic_kick/src/kick_engine.cpp
@@ -103,13 +103,15 @@ void KickEngine::calcSplines(const Eigen::Isometry3d &flying_foot_pose, const Ei
   /* build vector of speeds in each direction */
   double speed_yaw = rot_conv::EYawOfQuat(kick_direction_);
   Eigen::Vector3d speed_vector(cos(speed_yaw), sin(speed_yaw), 0);
+  double target_yaw = calcKickFootYaw();
 
   /* Flying foot position */
   flying_foot_spline_.x()->addPoint(0, flying_foot_pose.translation().x());
   flying_foot_spline_.x()->addPoint(phase_timings_.move_trunk, 0);
   flying_foot_spline_.x()->addPoint(phase_timings_.raise_foot, 0);
   flying_foot_spline_.x()->addPoint(phase_timings_.windup, windup_point_.x(), 0, 0);
-  flying_foot_spline_.x()->addPoint(phase_timings_.kick, ball_position_.x(),
+  flying_foot_spline_.x()->addPoint(phase_timings_.kick,
+                                    ball_position_.x() + params_.foot_extra_forward * cos(target_yaw),
                                     speed_vector.x() * kick_speed_, 0);
   flying_foot_spline_.x()->addPoint(phase_timings_.move_back, 0);
   flying_foot_spline_.x()->addPoint(phase_timings_.lower_foot, 0);
@@ -119,8 +121,9 @@ void KickEngine::calcSplines(const Eigen::Isometry3d &flying_foot_pose, const Ei
   flying_foot_spline_.y()->addPoint(phase_timings_.move_trunk, flying_foot_pose.translation().y());
   flying_foot_spline_.y()->addPoint(phase_timings_.raise_foot, kick_foot_sign * params_.foot_distance);
   flying_foot_spline_.y()->addPoint(phase_timings_.windup, windup_point_.y(), 0, 0);
-  flying_foot_spline_.y()
-      ->addPoint(phase_timings_.kick, ball_position_.y(), speed_vector.y() * kick_speed_, 0);
+  flying_foot_spline_.y()->addPoint(phase_timings_.kick,
+                                    ball_position_.y() + params_.foot_extra_forward * sin(target_yaw),
+                                    speed_vector.y() * kick_speed_, 0);
   flying_foot_spline_.y()->addPoint(phase_timings_.move_back, kick_foot_sign * params_.foot_distance);
   flying_foot_spline_.y()->addPoint(phase_timings_.lower_foot, kick_foot_sign * params_.foot_distance);
   flying_foot_spline_.y()->addPoint(phase_timings_.move_trunk_back, flying_foot_pose.translation().y());
@@ -139,7 +142,6 @@ void KickEngine::calcSplines(const Eigen::Isometry3d &flying_foot_pose, const Ei
   double start_r, start_p, start_y;
   Eigen::Quaterniond flying_foot_rotation(flying_foot_pose.rotation());
   rot_conv::EulerFromQuat(flying_foot_rotation, start_y, start_p, start_r);
-  double target_y = calcKickFootYaw();
 
   /* Add these quaternions in the same fashion as before to our splines (current, target, current) */
   flying_foot_spline_.roll()->addPoint(0, start_r);
@@ -150,8 +152,8 @@ void KickEngine::calcSplines(const Eigen::Isometry3d &flying_foot_pose, const Ei
   flying_foot_spline_.pitch()->addPoint(phase_timings_.move_trunk_back, start_p);
   flying_foot_spline_.yaw()->addPoint(0, start_y);
   flying_foot_spline_.yaw()->addPoint(phase_timings_.raise_foot, start_y);
-  flying_foot_spline_.yaw()->addPoint(phase_timings_.windup, target_y);
-  flying_foot_spline_.yaw()->addPoint(phase_timings_.kick, target_y);
+  flying_foot_spline_.yaw()->addPoint(phase_timings_.windup, target_yaw);
+  flying_foot_spline_.yaw()->addPoint(phase_timings_.kick, target_yaw);
   flying_foot_spline_.yaw()->addPoint(phase_timings_.move_back, start_y);
   flying_foot_spline_.yaw()->addPoint(phase_timings_.move_trunk_back, start_y);
 


### PR DESCRIPTION
## Proposed changes
Adds a parameter that makes the foot move further during a kick, so that we have a better chance to hit the ball if detection is a bit off.
Seems to make the kick a bit less stable though.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

