### PR TITLE
Change some warnings of the animation server to errors

### DIFF
--- a/bitbots_animation_server/src/bitbots_animation_server/animation_node.py
+++ b/bitbots_animation_server/src/bitbots_animation_server/animation_node.py
@@ -53,9 +53,9 @@ class PlayAnimationAction(object):
                 with open(animation_file) as fp:
                     self.animation_cache[animation_name] = parse(json.load(fp))
             except IOError:
-                rospy.logwarn("Animation '%s' could not be loaded" % animation_name)
+                rospy.logerr("Animation '%s' could not be loaded" % animation_name)
             except ValueError:
-                rospy.logwarn(
+                rospy.logerr(
                     "Animation '%s' had a ValueError. Probably there is a syntax error in the animation file. "
                     "See traceback" % animation_name)
                 traceback.print_exc()
@@ -137,7 +137,7 @@ class PlayAnimationAction(object):
 
     def get_animation_splines(self, animation_name):
         if animation_name not in self.animation_cache:
-            rospy.logwarn("Animation '%s' not found" % animation_name)
+            rospy.logerr("Animation '%s' not found" % animation_name)
             self._as.set_aborted(False, "Animation not found")
             return
 


### PR DESCRIPTION
## Proposed changes
Some warnings of the animation server are crucial and should not be ignored. Therefore they are changed to errors.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

