### PR TITLE
Fix access to ros parameters at import time

### DIFF
--- a/bitbots_hcm/src/bitbots_hcm/fall_checker.py
+++ b/bitbots_hcm/src/bitbots_hcm/fall_checker.py
@@ -12,18 +12,21 @@ from sklearn.metrics import accuracy_score
 
 class FallChecker(BaseEstimator):
 
-    def __init__(self, thresh_gyro_pitch=rospy.get_param("hcm/falling_thresh_gyro_pitch"),
-                 thresh_gyro_roll=rospy.get_param("hcm/falling_thresh_gyro_roll"),
-                 thresh_orient_pitch=math.radians(rospy.get_param("hcm/falling_thresh_orient_pitch")),
-                 thresh_orient_roll=math.radians(rospy.get_param("hcm/falling_thresh_orient_roll")),
-                 smoothing=rospy.get_param("hcm/smooth_threshold")):
+    def __init__(self, thresh_gyro_pitch=None,
+                 thresh_gyro_roll=None,
+                 thresh_orient_pitch=None,
+                 thresh_orient_roll=None,
+                 smoothing=None):
+        self.thresh_gyro_pitch = rospy.get_param("hcm/falling_thresh_gyro_pitch") \
+            if thresh_gyro_pitch is None else thresh_gyro_pitch
+        self.thresh_gyro_roll = rospy.get_param("hcm/falling_thresh_gyro_roll") \
+            if thresh_gyro_roll is None else thresh_gyro_roll
+        self.thresh_orient_pitch = math.radians(rospy.get_param("hcm/falling_thresh_orient_pitch")) \
+            if thresh_orient_pitch is None else thresh_orient_pitch
+        self.thresh_orient_roll = math.radians(rospy.get_param("hcm/falling_thresh_orient_roll")) \
+            if thresh_orient_roll is None else thresh_orient_roll
 
-        self.thresh_gyro_pitch = thresh_gyro_pitch
-        self.thresh_gyro_roll = thresh_gyro_roll
-        self.thresh_orient_pitch = thresh_orient_pitch
-        self.thresh_orient_roll = thresh_orient_roll
-
-        self.smoothing = smoothing
+        self.smoothing = rospy.get_param("hcm/smooth_threshold") if smoothing is None else smoothing
         self.smoothing_list = []
         self.counter = 0
         self.last_result = 0

--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/actions/play_animation.py
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/actions/play_animation.py
@@ -4,7 +4,6 @@ import humanoid_league_msgs.msg
 import bitbots_msgs.msg
 from actionlib_msgs.msg import GoalStatus
 from dynamic_stack_decider.abstract_action_element import AbstractActionElement
-from bitbots_hcm.hcm_dsd.hcm_blackboard import HcmBlackboard
 from time import sleep
 
 from humanoid_league_msgs.msg import RobotControlState


### PR DESCRIPTION
## Proposed changes
Currently, the default values for the fall checker are loaded as default values for keyword arguments. The problem is that these default values are accessed at import time. This can lead to undesired side effects when the fall checker or something that imports it, like the blackboard, is imported when the hcm parameters are not loaded.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

