### PR TITLE
Move bitbots_tests to the bottom

### DIFF
--- a/bitbots_dynamic_kick/CMakeLists.txt
+++ b/bitbots_dynamic_kick/CMakeLists.txt
@@ -54,11 +54,6 @@ catkin_package(
 
 enable_bitbots_docs()
 
-if (CATKIN_ENABLE_TESTING)
-    find_package(catkin REQUIRED COMPONENTS bitbots_test)
-    enable_bitbots_tests()
-endif()
-
 include_directories(
         include
         ${catkin_INCLUDE_DIRS}
@@ -85,3 +80,8 @@ set_target_properties(py_dynamic_kick PROPERTIES
         PREFIX ""
         LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}
 )
+
+if (CATKIN_ENABLE_TESTING)
+    find_package(catkin REQUIRED COMPONENTS bitbots_test)
+    enable_bitbots_tests()
+endif()


### PR DESCRIPTION
## Proposed changes
bitbots_test has to be at the bottom because the catkin libraries etc are overwritten by the second find_package.

## Related issues
Needed because of #288.

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board