### PR TITLE
Add simple test for dynup

### DIFF
--- a/bitbots_dynup/CMakeLists.txt
+++ b/bitbots_dynup/CMakeLists.txt
@@ -63,3 +63,8 @@ add_executable(DynupNode ${SOURCES})
 add_dependencies(DynupNode ${PROJECT_NAME}_gencfg ${PROJECT_NAME}_generate_messages)
 
 target_link_libraries(DynupNode ${catkin_LIBRARIES})
+
+if (CATKIN_ENABLE_TESTING)
+    find_package(catkin REQUIRED COMPONENTS bitbots_test)
+    enable_bitbots_tests()
+endif()

--- a/bitbots_dynup/package.xml
+++ b/bitbots_dynup/package.xml
@@ -25,6 +25,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>rotconv</depend>
   <depend>control_toolbox</depend>
+  <test_depend>bitbots_test</test_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/bitbots_dynup/test/rostests/test_dynup_runs.launch
+++ b/bitbots_dynup/test/rostests/test_dynup_runs.launch
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<launch>
+    <include file="$(find bitbots_bringup)/launch/load_robot_description.launch" />
+
+    <rosparam command="load" file="$(find bitbots_dynup)/config/dynup_sim.yaml" />
+
+    <node name="dynup" pkg="bitbots_dynup" type="DynupNode" output="screen" />
+
+    <node name="motors_helper" pkg="bitbots_bringup" type="motor_goals_viz_helper.py" args="--dynup" />
+
+    <test pkg="bitbots_dynup" type="test_dynup_runs.py" test-name="dynup_runs" time-limit="300" />
+</launch>

--- a/bitbots_dynup/test/rostests/test_dynup_runs.py
+++ b/bitbots_dynup/test/rostests/test_dynup_runs.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+from bitbots_test.test_case import RosNodeTestCase
+from bitbots_test.mocks import MockSubscriber
+from actionlib_msgs.msg import GoalStatus
+from bitbots_msgs.msg import DynUpAction, DynUpGoal, JointCommand
+import actionlib
+
+
+class DynupRunsTestCase(RosNodeTestCase):
+    def one_run(self, direction):
+        def done_cb(state, result):
+            assert state == GoalStatus.SUCCEEDED, "Dynup was not successful"
+            self.kick_succeeded = True
+
+        self.kick_succeeded = False
+
+        sub = MockSubscriber('dynup_motor_goals', JointCommand)
+        self.with_assertion_grace_period(lambda: self.assertNodeRunning("dynup"), 20)
+        client = actionlib.SimpleActionClient('dynup', DynUpAction)
+        assert client.wait_for_server(), "Dynup action server not running"
+
+        goal = DynUpGoal()
+        goal.direction = direction
+        client.send_goal(goal)
+        client.done_cb = done_cb
+        client.wait_for_result()
+        sub.wait_until_connected()
+        sub.assertMessageReceived()
+        assert self.kick_succeeded, "Dynup was not successful"
+
+    def test_walkready(self):
+        self.one_run("walkready")
+
+    def test_front(self):
+        self.one_run("front")
+
+    def test_back(self):
+        self.one_run("back")
+
+    def test_rise(self):
+        self.one_run("rise")
+
+    def test_descend(self):
+        self.one_run("descend")
+
+if __name__ == '__main__':
+    from bitbots_test import run_rostests
+    run_rostests(DynupRunsTestCase)


### PR DESCRIPTION
## Proposed changes
Basically the same as #288.
Tests for all directions if they do anything. Would have prevented #287 and the abortion of our test game today.

## Necessary checks
- [ ] Update package version
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

