### PR TITLE
hcm: not usesd parameter

### DIFF
--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/decisions/decisions.py
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/decisions/decisions.py
@@ -129,7 +129,7 @@ class CheckMotors(AbstractDecisionElement):
             return "TURN_OFF"
 
         # see if we get no messages or always the exact same
-        if self.blackboard.current_time.to_sec() - self.last_different_msg_time.to_sec() > 0.1:
+        if self.blackboard.current_time.to_sec() - self.last_different_msg_time.to_sec() > self.blackboard.motor_timeout_duration:
             if self.blackboard.is_power_on:
                 if (self.blackboard.current_state == RobotControlState.STARTUP and
                         self.blackboard.current_time.to_sec() - self.blackboard.start_time.to_sec() < 10):


### PR DESCRIPTION
Parameter was hard coded instead using the one from config

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

