### PR TITLE
hcm: not usesd parameter

### DIFF
--- a/bitbots_hcm/src/bitbots_hcm/hcm_dsd/decisions/decisions.py
+++ b/bitbots_hcm/src/bitbots_hcm/hcm_dsd/decisions/decisions.py
@@ -129,7 +129,7 @@ class CheckMotors(AbstractDecisionElement):
             return "TURN_OFF"
 
         # see if we get no messages or always the exact same
-        if self.blackboard.current_time.to_sec() - self.last_different_msg_time.to_sec() > 0.1:
+        if self.blackboard.current_time.to_sec() - self.last_different_msg_time.to_sec() > self.blackboard.motor_timeout_duration:
             if self.blackboard.is_power_on:
                 if (self.blackboard.current_state == RobotControlState.STARTUP and
                         self.blackboard.current_time.to_sec() - self.blackboard.start_time.to_sec() < 10):


### PR DESCRIPTION
## Proposed changes
The HCM was not using one of its parameters but had a hardcoded value

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [x] Test on the robot
- [x] Put the PR on our Project board

