### PR TITLE
Fix rot_conv dep

### DIFF
--- a/bitbots_dynamic_kick/CMakeLists.txt
+++ b/bitbots_dynamic_kick/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(moveit_ros_planning_interface REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
-find_package(rotconv REQUIRED)
+find_package(rot_conv REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tf2 REQUIRED)
@@ -67,7 +67,7 @@ ament_target_dependencies(KickNode
         moveit_ros_planning_interface
         nav_msgs
         rclcpp
-        rotconv
+        rot_conv
         sensor_msgs
         std_msgs
         tf2
@@ -103,7 +103,7 @@ target_link_libraries(KickNode "${cpp_typesupport_target}")
 #        nav_msgs
 #        rclcpp
 #        ros2_python_extension
-#        rotconv
+#        rot_conv
 #        sensor_msgs
 #        std_msgs
 #        tf2

--- a/bitbots_dynamic_kick/package.xml
+++ b/bitbots_dynamic_kick/package.xml
@@ -34,7 +34,7 @@
     <depend>moveit_ros_planning_interface</depend>
     <depend>rclcpp</depend>
     <depend>ros2_python_extension</depend>
-    <depend>rotconv</depend>
+    <depend>rot_conv</depend>
     <depend>std_msgs</depend>
     <depend>tf2</depend>
     <depend>tf2_eigen</depend>

--- a/bitbots_dynup/CMakeLists.txt
+++ b/bitbots_dynup/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(moveit_ros REQUIRED)
 find_package(moveit_ros_planning_interface REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
-find_package(rotconv REQUIRED)
+find_package(rot_conv REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tf2 REQUIRED)
@@ -67,7 +67,7 @@ ament_target_dependencies(DynupNode
         moveit_ros_planning_interface
         rclcpp
         ros2_python_extension
-        rotconv
+        rot_conv
         sensor_msgs
         std_msgs
         tf2
@@ -96,7 +96,7 @@ ament_target_dependencies(libpy_dynup PUBLIC
         moveit_ros_planning_interface
         rclcpp
         ros2_python_extension
-        rotconv
+        rot_conv
         sensor_msgs
         std_msgs
         tf2

--- a/bitbots_dynup/package.xml
+++ b/bitbots_dynup/package.xml
@@ -26,7 +26,7 @@
   <depend>moveit_ros_robot_interaction</depend>
   <depend>moveit_ros_planning_interface</depend>
   <depend>bitbots_docs</depend>
-  <depend>rotconv</depend>
+  <depend>rot_conv</depend>
   <depend>control_toolbox</depend>
   <depend>ros2_python_extension</depend>
   <depend>backward_ros</depend>

--- a/bitbots_odometry/CMakeLists.txt
+++ b/bitbots_odometry/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(tf2_geometry_msgs REQUIRED)
 find_package(biped_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(bitbots_docs REQUIRED)
-find_package(rotconv REQUIRED)
+find_package(rot_conv REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(ament_cmake REQUIRED)
@@ -38,7 +38,7 @@ ament_target_dependencies(motion_odometry
         biped_interfaces
         geometry_msgs
         bitbots_docs
-        rotconv
+        rot_conv
         sensor_msgs
         tf2_ros
         ament_cmake
@@ -53,7 +53,7 @@ ament_target_dependencies(odometry_fuser
         biped_interfaces
         geometry_msgs
         bitbots_docs
-        rotconv
+        rot_conv
         sensor_msgs
         tf2_ros
         ament_cmake

--- a/bitbots_odometry/package.xml
+++ b/bitbots_odometry/package.xml
@@ -19,7 +19,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>
-  <depend>rotconv</depend>
+  <depend>rot_conv</depend>
   <depend>bitbots_docs</depend>
   <depend>biped_interfaces</depend>
 

--- a/bitbots_quintic_walk/CMakeLists.txt
+++ b/bitbots_quintic_walk/CMakeLists.txt
@@ -23,7 +23,7 @@ find_package(moveit_ros_planning_interface REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
-find_package(rotconv REQUIRED)
+find_package(rot_conv REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(tf2 REQUIRED)
@@ -68,7 +68,7 @@ ament_target_dependencies(WalkNode
         moveit_ros_planning_interface
         nav_msgs
         rclcpp
-        rotconv
+        rot_conv
         sensor_msgs
         std_msgs
         tf2
@@ -103,7 +103,7 @@ ament_target_dependencies(libpy_quintic_walk PUBLIC
         nav_msgs
         rclcpp
         ros2_python_extension
-        rotconv
+        rot_conv
         sensor_msgs
         std_msgs
         tf2

--- a/bitbots_quintic_walk/package.xml
+++ b/bitbots_quintic_walk/package.xml
@@ -37,7 +37,7 @@
     <depend>moveit_ros_planning_interface</depend>
     <depend>rclcpp</depend>
     <depend>ros2_python_extension</depend>
-    <depend>rotconv</depend>
+    <depend>rot_conv</depend>
     <depend>std_msgs</depend>
     <depend>tf2</depend>
     <depend>tf2_eigen</depend>


### PR DESCRIPTION
## Proposed changes
The dependency `rotconv` was renamed to `rot_conv`

## Related issues
bit-bots/rot_conv_lib/pull/5
ros-sports/humanoid_base_footprint/pull/37

## Necessary checks
- [x] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

