### PR TITLE
odom: fix z value of odom

### DIFF
--- a/bitbots_odometry/src/motion_odometry.cpp
+++ b/bitbots_odometry/src/motion_odometry.cpp
@@ -140,7 +140,7 @@ void MotionOdometry::loop() {
       }
       double y = current_support_to_base.getOrigin().y() * y_scaling_;
       double yaw = tf2::getYaw(current_support_to_base.getRotation()) * x_backward_scaling_;
-      current_support_to_base.setOrigin({x, y, 0});
+      current_support_to_base.setOrigin({x, y, current_support_to_base.getOrigin().z()});
       tf2::Quaternion q;
       q.setRPY(0, 0, yaw);
       current_support_to_base.setRotation(q);


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes and why they are necessary. -->
Small fix for odom z value that was wrongly set to 0 in https://github.com/bit-bots/bitbots_motion/pull/325

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

