### PR TITLE
Disable walk pid controllers

### DIFF
--- a/bitbots_quintic_walk/config/walking_wolfgang_robot.yaml
+++ b/bitbots_quintic_walk/config/walking_wolfgang_robot.yaml
@@ -65,7 +65,7 @@ walking:
 
 walk_pid_trunk_fused_pitch:
   ros__parameters:
-    p: 0.25
+    p: 0.0
     i: 0.0
     d: 0.0
     i_clamp: 0.0
@@ -75,7 +75,7 @@ walk_pid_trunk_fused_pitch:
 
 walk_pid_trunk_fused_roll:
   ros__parameters:
-    p: 0.111
+    p: 0.0
     i: 0.0
     d: 0.0
     i_clamp: 0.0


### PR DESCRIPTION
This disables the PID controllers in the walking for now because they are unstable. Smaller values can probably be added back later when the final parameters are done.