### PR TITLE
Fix/dynup ik init

### DIFF
--- a/bitbots_dynup/src/dynup_ik.cpp
+++ b/bitbots_dynup/src/dynup_ik.cpp
@@ -15,9 +15,13 @@ void DynupIK::init(moveit::core::RobotModelPtr kinematic_model) {
 }
 
 void DynupIK::reset() {
-
-  for (size_t i = 0; i < current_joint_states_->name.size(); i++) {
-    goal_state_->setJointPositions(current_joint_states_->name[i], &current_joint_states_->position[i]);
+  // we have to set some good initial position in the goal state, since we are using a gradient
+  // based method. Otherwise, the first step will be not correct
+  std::vector<std::string> names_vec = {"LHipPitch", "LKnee", "LAnklePitch", "RHipPitch", "RKnee", "RAnklePitch"};
+  std::vector<double> pos_vec = {0.7, 1.0, -0.4, -0.7, -1.0, 0.4};
+  for (size_t i = 0; i < names_vec.size(); i++) {
+    // besides its name, this method only changes a single joint position...
+    goal_state_->setJointPositions(names_vec[i], &pos_vec[i]);
   }
 }
 

--- a/bitbots_hcm/bitbots_hcm/hcm_dsd/decisions/decisions.py
+++ b/bitbots_hcm/bitbots_hcm/hcm_dsd/decisions/decisions.py
@@ -32,7 +32,7 @@ class StartHCM(AbstractDecisionElement):
         """
         We check if any joint is has an offset from the walkready pose which is higher than a threshold
         """
-        if self.blackboard.current_joint_state is None or self.blackboard.current_joint_state == []:
+        if self.blackboard.current_joint_state is None or self.blackboard.current_joint_state.name == []:
             return False
         i = 0
         for joint_name in self.blackboard.current_joint_state.name:


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes and why they are necessary. -->
Init was causing weird ik solutions when motors were off previously. Now it uses the same approach as the walking and sets critical motors to a safe pose first.

## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Necessary checks
- [ ] Update package version
- [x] Run ~~catkin~~ `colcon build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [x] Test on the robot
- [x] Put the PR on our Project board

