### PR TITLE
Fix hcm build warning

### DIFF
--- a/bitbots_hcm/CMakeLists.txt
+++ b/bitbots_hcm/CMakeLists.txt
@@ -20,6 +20,10 @@ find_package(ros2_python_extension REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-fvisibility=hidden)
+endif()
+
 include_directories(${PYTHON_INCLUDE_DIRS})
 set(SOURCES src/hcm.cpp)
 


### PR DESCRIPTION
## Proposed changes
Adds [required](https://pybind11.readthedocs.io/en/stable/faq.html#someclass-declared-with-greater-visibility-than-the-type-of-its-field-someclass-member-wattributes) compiler flag, which also fixes build warning.
