### PR TITLE
Fix uninitialized value

### DIFF
--- a/bitbots_dynamic_kick/src/kick_node.cpp
+++ b/bitbots_dynamic_kick/src/kick_node.cpp
@@ -46,7 +46,7 @@ KickNode::KickNode(const std::string &ns, std::vector<rclcpp::Parameter> paramet
   this->get_parameter("spline_smoothness", viz_params.spline_smoothness);
   visualizer_.setParams(viz_params);
   this->get_parameter("engine_rate", engine_rate_);
-  bool use_center_of_pressure;
+  bool use_center_of_pressure = false;
   this->get_parameter("use_center_of_pressure", use_center_of_pressure);
   stabilizer_.useCop(use_center_of_pressure);
 


### PR DESCRIPTION
```
/colcon_ws/src/bitbots_meta/bitbots_motion/bitbots_dynamic_kick/src/kick_node.cpp: In constructor ‘bitbots_dynamic_kick::KickNode::KickNode(const string&, std::vector<rclcpp::Parameter>)’:
/colcon_ws/src/bitbots_meta/bitbots_motion/bitbots_dynamic_kick/src/kick_node.cpp:51:21: error: ‘use_center_of_pressure’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   51 |   stabilizer_.useCop(use_center_of_pressure);
      |   ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
gmake[2]: *** [CMakeFiles/KickNode.dir/build.make:76: CMakeFiles/KickNode.dir/src/kick_node.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:594: CMakeFiles/KickNode.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```