### PR TITLE
Removed unused import

### DIFF
--- a/bitbots_hcm/bitbots_hcm/hcm_dsd/actions/falling_poses.py
+++ b/bitbots_hcm/bitbots_hcm/hcm_dsd/actions/falling_poses.py
@@ -1,4 +1,3 @@
-from turtle import pos
 from dynamic_stack_decider.abstract_action_element import AbstractActionElement
 from bitbots_hcm.hcm_dsd.hcm_blackboard import HcmBlackboard
 from rclpy.duration import Duration


### PR DESCRIPTION
This unused import requires `tkinter` and I don't even understand why it is there...