### PR TITLE
Fix bio ik usage in moveit bindings

### DIFF
--- a/bitbots_moveit_bindings/CMakeLists.txt
+++ b/bitbots_moveit_bindings/CMakeLists.txt
@@ -24,6 +24,7 @@ find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_kdl REQUIRED)
 find_package(irobot_events_executor REQUIRED)
+find_package(rclcpp REQUIRED)
 
 add_compile_options(-Wall -Wno-unused)
 
@@ -41,6 +42,7 @@ ament_target_dependencies(libbitbots_moveit_bindings PUBLIC
   moveit_msgs
   moveit_ros_planning_interface
   moveit_ros_planning
+  rclcpp
   ros2_python_extension
   tf2
   tf2_ros

--- a/bitbots_moveit_bindings/bitbots_moveit_bindings/__init__.py
+++ b/bitbots_moveit_bindings/bitbots_moveit_bindings/__init__.py
@@ -3,6 +3,7 @@ from bitbots_moveit_bindings.libbitbots_moveit_bindings import BitbotsMoveitBind
 from rclpy.serialization import serialize_message, deserialize_message
 from rcl_interfaces.msg import Parameter
 from bio_ik_msgs.srv import GetIK
+from bio_ik_msgs.msg import IKRequest
 from sensor_msgs.msg import JointState
 
 # this state is only used for IK and FK calls and does not listen to current joint_states
@@ -45,17 +46,17 @@ def get_position_fk(request: GetPositionFK.Request):
     result_str = ik_fk_state.getPositionFK(serialize_message(request))
     return deserialize_message(result_str, GetPositionFK.Response)
 
-def get_bioik_ik():
+def get_bioik_ik(request: IKRequest):
     global ik_fk_state
     if ik_fk_state is None:
         ik_fk_state = BitbotsMoveitBindings([])
-    result_str = ik_fk_state.getBioIKIK()
+    result_str = ik_fk_state.getBioIKIK(serialize_message(request))
     return deserialize_message(result_str, GetIK.Response)
 
 def check_collision(joint_state):
     global collision_state
     if collision_state is None:
         collision_state = BitbotsMoveitBindings([])
-    set_joint_states(serialize_message(joint_state))
+    collision_state.set_joint_states(serialize_message(joint_state))
     collision = collision_state.check_collision()
     return collision

--- a/bitbots_moveit_bindings/package.xml
+++ b/bitbots_moveit_bindings/package.xml
@@ -22,4 +22,4 @@
 
   <build_type>ament_cmake</build_type>
   </export>
-    </package>
+</package>

--- a/bitbots_moveit_bindings/src/bitbots_moveit_bindings.cpp
+++ b/bitbots_moveit_bindings/src/bitbots_moveit_bindings.cpp
@@ -363,6 +363,7 @@ PYBIND11_MODULE(libbitbots_moveit_bindings, m) {
       .def(py::init<std::vector<py::bytes>>())
       .def("getPositionIK", &BitbotsMoveitBindings::getPositionIK)
       .def("getPositionFK", &BitbotsMoveitBindings::getPositionFK)
+      .def("getBioIKIK", &BitbotsMoveitBindings::getBioIKIK)
       .def("set_head_motors", &BitbotsMoveitBindings::setHeadMotors,
            "Set the current pan and tilt joint values [radian]", py::arg("pan"), py::arg("tilt"))
       .def("set_joint_states", &BitbotsMoveitBindings::setJointStates, "Set the current joint states")


### PR DESCRIPTION
## Proposed changes
This PR fixes the usage of bitbots_moveit_bindings with the bio_ik as it is used for `LookAt` in the behavior.

## Necessary checks
- [x] Run `colcon build`
- [ ] Write documentation
- [ ] Create issues for future work
- [x] Test on your machine
- [ ] Test on the robot
- [x] Put the PR on our Project board

