### PR TITLE
Fix the word "HCM" in the TTS

### DIFF
--- a/bitbots_hcm/bitbots_hcm/humanoid_control_module.py
+++ b/bitbots_hcm/bitbots_hcm/humanoid_control_module.py
@@ -82,7 +82,7 @@ class HardwareControlManager:
 
         # important to make sure the connection to the speaker is established, for next line
         self.node.get_clock().sleep_for(Duration(seconds=0.1))
-        speak("Starting hcm", self.blackboard.speak_publisher, priority=50)
+        speak("Starting HCM", self.blackboard.speak_publisher, priority=50)
         self.node.create_subscription(Bool, "pause", self.pause, 1)
         self.node.create_subscription(Bool, "core/power_switch_status", self.power_cb, 1)
         self.node.create_subscription(Bool, "hcm_deactivate", self.deactivate_cb, 1)


### PR DESCRIPTION
## Proposed changes
- Write it in caps so it is pronounced "H C M" otherwise it is skipped by the new tts.
