### PR TITLE
check for initial ourselves instead of using reevaluate

### DIFF
--- a/bitbots_hcm/bitbots_hcm/hcm_dsd/decisions/decisions.py
+++ b/bitbots_hcm/bitbots_hcm/hcm_dsd/decisions/decisions.py
@@ -23,6 +23,10 @@ class StartHCM(AbstractHCMDecisionElement):
     Initializes HCM.
     """
 
+    def __init__(self, blackboard, dsd, parameters=None):
+        super().__init__(blackboard, dsd, parameters)
+        self.is_initial = True
+
     def perform(self, reevaluate=False):
         if self.blackboard.shut_down_request:
             if self.blackboard.current_state == RobotControlState.HARDWARE_PROBLEM:
@@ -32,9 +36,11 @@ class StartHCM(AbstractHCMDecisionElement):
                 self.blackboard.current_state = RobotControlState.SHUTDOWN
                 return "SHUTDOWN_REQUESTED"
         else:
-            if not reevaluate:
+            if self.is_initial:
                 if not self.is_walkready():
                     return "NOT_WALKREADY"
+                else:
+                    self.is_initial = False
                 self.blackboard.current_state = RobotControlState.STARTUP
             return "RUNNING"
 

--- a/bitbots_hcm/bitbots_hcm/hcm_dsd/hcm.dsd
+++ b/bitbots_hcm/bitbots_hcm/hcm_dsd/hcm.dsd
@@ -5,7 +5,7 @@ $PickedUp
 
 -->HCM
 $StartHCM
-    NOT_WALKREADY --> @Wait + time:0.1, @PlayAnimationDynup + direction:walkready + initial:true
+    NOT_WALKREADY --> @Wait + time:0.1 + r:false, @PlayAnimationDynup + direction:walkready + initial:true + r:false
     SHUTDOWN_REQUESTED --> #ShutDownProcedure
     SHUTDOWN_WHILE_HARDWARE_PROBLEM --> @StayShutDown
     RUNNING --> $Stop


### PR DESCRIPTION
robot did only rarely go into walkready on startup, works consistently now
