### PR TITLE
Use rclcpp events executor

### DIFF
--- a/bitbots_dynup/CMakeLists.txt
+++ b/bitbots_dynup/CMakeLists.txt
@@ -28,7 +28,6 @@ find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(backward_ros REQUIRED)
-find_package(irobot_events_executor REQUIRED)
 
 find_package(ros2_python_extension REQUIRED)
 find_package(pybind11 REQUIRED)
@@ -63,7 +62,6 @@ ament_target_dependencies(DynupNode
         control_msgs
         control_toolbox
         geometry_msgs
-        irobot_events_executor
         moveit_ros_planning_interface
         rclcpp
         ros2_python_extension
@@ -92,7 +90,6 @@ ament_target_dependencies(libpy_dynup PUBLIC
         control_msgs
         control_toolbox
         geometry_msgs
-        irobot_events_executor
         moveit_ros_planning_interface
         rclcpp
         ros2_python_extension

--- a/bitbots_dynup/include/bitbots_dynup/dynup_node.h
+++ b/bitbots_dynup/include/bitbots_dynup/dynup_node.h
@@ -9,7 +9,7 @@
 #include <unistd.h>
 
 #include "rclcpp_action/rclcpp_action.hpp"
-#include <rclcpp/executors/events_executor/events_executor.hpp>
+#include <rclcpp/experimental/executors/events_executor/events_executor.hpp>
 #include <std_msgs/msg/char.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>

--- a/bitbots_dynup/package.xml
+++ b/bitbots_dynup/package.xml
@@ -23,7 +23,6 @@
   <depend>moveit_ros_move_group</depend>
   <depend>bitbots_splines</depend>
   <depend>geometry_msgs</depend>
-  <depend>irobot_events_executor</depend>
   <depend>bitbots_msgs</depend>
   <depend>moveit_ros_robot_interaction</depend>
   <depend>moveit_ros_planning_interface</depend>

--- a/bitbots_dynup/src/dynup_node.cpp
+++ b/bitbots_dynup/src/dynup_node.cpp
@@ -408,7 +408,7 @@ int main(int argc, char **argv) {
   rclcpp::init(argc, argv);
   // init node
   auto node = std::make_shared<bitbots_dynup::DynupNode>();
-  rclcpp::executors::EventsExecutor exec;
+  rclcpp::experimental::executors::EventsExecutor exec;
   exec.add_node(node);
 
   exec.spin();

--- a/bitbots_hcm/CMakeLists.txt
+++ b/bitbots_hcm/CMakeLists.txt
@@ -11,7 +11,6 @@ find_package(bitbots_msgs REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(humanoid_league_msgs REQUIRED)
-find_package(irobot_events_executor REQUIRED)
 find_package(pybind11 REQUIRED)
 find_package(Python3 REQUIRED)
 find_package(PythonLibs REQUIRED)
@@ -36,7 +35,6 @@ ament_target_dependencies(HCM
     builtin_interfaces
     geometry_msgs
     humanoid_league_msgs
-    irobot_events_executor
     rclcpp
     ros2_python_extension
     sensor_msgs

--- a/bitbots_hcm/package.xml
+++ b/bitbots_hcm/package.xml
@@ -22,7 +22,6 @@
   <depend>bitbots_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>humanoid_league_msgs</depend>
-  <depend>irobot_events_executor</depend>
   <depend>pybind11-dev</depend>
   <depend>rclpy</depend>
   <depend>ros2_python_extension</depend>

--- a/bitbots_hcm/src/hcm.cpp
+++ b/bitbots_hcm/src/hcm.cpp
@@ -13,7 +13,7 @@
 #include "builtin_interfaces/msg/time.hpp"
 #include <ros2_python_extension/serialization.hpp>
 #include "std_msgs/msg/header.hpp"
-#include <rclcpp/executors/events_executor/events_executor.hpp>
+#include <rclcpp/experimental/executors/events_executor/events_executor.hpp>
 
 
 using std::placeholders::_1;
@@ -268,7 +268,7 @@ private:
 };
 }  // namespace bitbots_hcm
 
-void thread_spin(rclcpp::executors::EventsExecutor::SharedPtr executor){
+void thread_spin(rclcpp::experimental::executors::EventsExecutor::SharedPtr executor){
   executor->spin();
 }
 
@@ -276,7 +276,7 @@ int main(int argc, char** argv) {
   rclcpp::init(argc, argv);
   auto node = std::make_shared<bitbots_hcm::HCM_CPP>();
 
-  rclcpp::executors::EventsExecutor::SharedPtr exec = std::make_shared<rclcpp::executors::EventsExecutor>();
+  rclcpp::experimental::executors::EventsExecutor::SharedPtr exec = std::make_shared<rclcpp::experimental::executors::EventsExecutor>();
   exec->add_node(node);
   std::thread thread_obj(thread_spin, exec);
 

--- a/bitbots_moveit_bindings/CMakeLists.txt
+++ b/bitbots_moveit_bindings/CMakeLists.txt
@@ -23,7 +23,6 @@ find_package(ros2_python_extension)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_kdl REQUIRED)
-find_package(irobot_events_executor REQUIRED)
 find_package(rclcpp REQUIRED)
 
 add_compile_options(-Wall -Wno-unused)
@@ -47,7 +46,6 @@ ament_target_dependencies(libbitbots_moveit_bindings PUBLIC
   tf2
   tf2_ros
   tf2_kdl
-  irobot_events_executor
 )
 
 ament_python_install_package(${PROJECT_NAME})

--- a/bitbots_moveit_bindings/package.xml
+++ b/bitbots_moveit_bindings/package.xml
@@ -18,7 +18,6 @@
   <depend>moveit_ros_planning_interface</depend>
   <depend>pybind11_vendor</depend>
   <depend>ros2_python_extension</depend>
-  <depend>irobot_events_executor</depend>
   <export>
 
   <build_type>ament_cmake</build_type>

--- a/bitbots_moveit_bindings/src/bitbots_moveit_bindings.cpp
+++ b/bitbots_moveit_bindings/src/bitbots_moveit_bindings.cpp
@@ -18,7 +18,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <ros2_python_extension/serialization.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
-#include <rclcpp/executors/events_executor/events_executor.hpp>
+#include <rclcpp/experimental/executors/events_executor/events_executor.hpp>
 
 #include "rcl_interfaces/srv/get_parameters.hpp"
 namespace py = pybind11;
@@ -88,7 +88,7 @@ public:
     if (!planning_scene_) {
       RCLCPP_ERROR_ONCE(node_->get_logger(), "failed to connect to planning scene");
     }
-    exec_ = std::make_shared<rclcpp::executors::EventsExecutor>();
+    exec_ = std::make_shared<rclcpp::experimental::executors::EventsExecutor>();
     exec_->add_node(node_);
   }
 
@@ -269,7 +269,7 @@ private:
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
   planning_scene::PlanningScenePtr planning_scene_;
   std::shared_ptr<rclcpp::Node> node_;
-  std::shared_ptr<rclcpp::executors::EventsExecutor> exec_;
+  std::shared_ptr<rclcpp::experimental::executors::EventsExecutor> exec_;
   std::thread t_;
 
   static tf2::Vector3 p(const geometry_msgs::msg::Point& p) {

--- a/bitbots_odometry/CMakeLists.txt
+++ b/bitbots_odometry/CMakeLists.txt
@@ -20,7 +20,6 @@ find_package(tf2_ros REQUIRED)
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(Eigen3 REQUIRED)
-find_package(irobot_events_executor REQUIRED)
 
 include_directories(include)
 
@@ -43,7 +42,6 @@ ament_target_dependencies(motion_odometry
         sensor_msgs
         tf2_ros
         ament_cmake
-        irobot_events_executor
         rclcpp)
 
 ament_target_dependencies(odometry_fuser
@@ -60,7 +58,6 @@ ament_target_dependencies(odometry_fuser
         tf2_ros
         ament_cmake
         rclcpp
-        irobot_events_executor
         Eigen3)
 
 enable_bitbots_docs()

--- a/bitbots_odometry/include/bitbots_odometry/motion_odometry.h
+++ b/bitbots_odometry/include/bitbots_odometry/motion_odometry.h
@@ -9,7 +9,7 @@
 #include <biped_interfaces/msg/phase.hpp>
 #include <unistd.h>
 #include <tf2_ros/buffer.h>
-#include <rclcpp/executors/events_executor/events_executor.hpp>
+#include <rclcpp/experimental/executors/events_executor/events_executor.hpp>
 
 using std::placeholders::_1;
 

--- a/bitbots_odometry/include/bitbots_odometry/odometry_fuser.h
+++ b/bitbots_odometry/include/bitbots_odometry/odometry_fuser.h
@@ -22,7 +22,7 @@
 #include <message_filters/sync_policies/approximate_time.h>
 #include <biped_interfaces/msg/phase.hpp>
 #include <unistd.h>
-#include <rclcpp/executors/events_executor/events_executor.hpp>
+#include <rclcpp/experimental/executors/events_executor/events_executor.hpp>
 
 using std::placeholders::_1;
 

--- a/bitbots_odometry/package.xml
+++ b/bitbots_odometry/package.xml
@@ -23,7 +23,6 @@
   <depend>rot_conv</depend>
   <depend>bitbots_docs</depend>
   <depend>biped_interfaces</depend>
-  <depend>irobot_events_executor</depend>
 
   <export>
     <bitbots_documentation>

--- a/bitbots_odometry/src/motion_odometry.cpp
+++ b/bitbots_odometry/src/motion_odometry.cpp
@@ -223,7 +223,7 @@ int main(int argc, char **argv) {
 
   rclcpp::Duration timer_duration = rclcpp::Duration::from_seconds(1.0 / 200.0);
   rclcpp::TimerBase::SharedPtr timer = rclcpp::create_timer(node, node->get_clock(), timer_duration, [node]() -> void {node->loop();});
-  rclcpp::executors::EventsExecutor exec;
+  rclcpp::experimental::executors::EventsExecutor exec;
   exec.add_node(node);
 
   exec.spin();

--- a/bitbots_odometry/src/odometry_fuser.cpp
+++ b/bitbots_odometry/src/odometry_fuser.cpp
@@ -249,7 +249,7 @@ void OdometryFuser::imuCallback(
 int main(int argc, char **argv) {
   rclcpp::init(argc, argv);
   auto node = std::make_shared<OdometryFuser>();
-  rclcpp::executors::EventsExecutor exec;
+  rclcpp::experimental::executors::EventsExecutor exec;
   exec.add_node(node);
   while(!node->wait_for_tf()){
      exec.spin_some();

--- a/bitbots_quintic_walk/CMakeLists.txt
+++ b/bitbots_quintic_walk/CMakeLists.txt
@@ -19,7 +19,6 @@ find_package(control_toolbox REQUIRED)
 find_package(generate_parameter_library REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(humanoid_league_msgs REQUIRED)
-find_package(irobot_events_executor REQUIRED)
 find_package(moveit_ros_planning_interface REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -72,7 +71,6 @@ ament_target_dependencies(WalkNode
         control_toolbox
         geometry_msgs
         humanoid_league_msgs
-        irobot_events_executor
         moveit_ros_planning_interface
         nav_msgs
         rclcpp
@@ -102,7 +100,6 @@ ament_target_dependencies(libpy_quintic_walk PUBLIC
         control_toolbox
         geometry_msgs
         humanoid_league_msgs
-        irobot_events_executor
         moveit_ros_planning_interface
         nav_msgs
         rclcpp

--- a/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_node.h
+++ b/bitbots_quintic_walk/include/bitbots_quintic_walk/walk_node.h
@@ -41,7 +41,7 @@ https://github.com/Rhoban/model/
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include <moveit/kinematics_base/kinematics_base.h>
 #include <moveit/move_group_interface/move_group_interface.h>
-#include <rclcpp/executors/events_executor/events_executor.hpp>
+#include <rclcpp/experimental/executors/events_executor/events_executor.hpp>
 
 #include "bitbots_quintic_walk/walk_engine.h"
 #include "bitbots_quintic_walk/walk_stabilizer.h"

--- a/bitbots_quintic_walk/package.xml
+++ b/bitbots_quintic_walk/package.xml
@@ -33,7 +33,6 @@
     <depend>generate_parameter_library</depend>
     <depend>geometry_msgs</depend>
     <depend>humanoid_league_msgs</depend>
-    <depend>irobot_events_executor</depend>
     <depend>moveit_core</depend>
     <depend>moveit_ros_move_group</depend>
     <depend>moveit_ros_planning_interface</depend>

--- a/bitbots_quintic_walk/src/walk_node.cpp
+++ b/bitbots_quintic_walk/src/walk_node.cpp
@@ -637,7 +637,7 @@ int main(int argc, char **argv) {
   node->initializeEngine();
   rclcpp::Duration timer_duration = rclcpp::Duration::from_seconds(1.0 / node->getTimerFreq());
   rclcpp::TimerBase::SharedPtr timer = rclcpp::create_timer(node, node->get_clock(), timer_duration, [node]() -> void {node->run();});
-  rclcpp::executors::EventsExecutor exec;
+  rclcpp::experimental::executors::EventsExecutor exec;
   exec.add_node(node);
 
   exec.spin();


### PR DESCRIPTION
## Proposed changes
- Use released events executor binaries from rclcpp


PR because https://github.com/ros2/rclcpp/pull/2155 is merged and released.