### PR TITLE
Fix wrong robotcontrolstate type

### DIFF
--- a/bitbots_hcm/bitbots_hcm/humanoid_control_module.py
+++ b/bitbots_hcm/bitbots_hcm/humanoid_control_module.py
@@ -14,7 +14,7 @@ from std_msgs.msg import Bool
 from sensor_msgs.msg import Imu, JointState
 from diagnostic_msgs.msg import DiagnosticArray
 
-from humanoid_league_msgs.msg import Animation as  RobotControlState, Audio
+from humanoid_league_msgs.msg import RobotControlState, Audio
 from humanoid_league_msgs.action import PlayAnimation
 from humanoid_league_speaker.speaker import speak
 from bitbots_msgs.msg import FootPressure


### PR DESCRIPTION
## Proposed changes
<!--- Describe your changes and why they are necessary. -->
HCM would die as it expected an animation
## Related issues
<!--- Mention (link) related issues. -->
<!--- If you suggest a new feature, please discuss it in an issue first. -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

## Necessary checks
- [ ] Update package version
- [ ] Run `catkin build`
- [ ] Write documentation
- [ ] Create issues for future work
- [ ] Test on your machine
- [ ] Test on the robot
- [ ] Put the PR on our Project board

